### PR TITLE
Update PZNS_UtilsNPCs.lua

### DIFF
--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
@@ -95,7 +95,7 @@ function PZNS_UtilsNPCs.PZNS_AddEquipClothingNPCSurvivor(npcSurvivor, clothingID
         npcIsoPlayer:getInventory():AddItem(clothingItem);
         local bodyPartLocation = clothingItem:getBodyLocation();
         --
-        if (bodyPartLocation ~= nil) then
+        if (bodyPartLocation ~= nil and bodyPartLocation ~= '') then
             npcIsoPlayer:setWornItem(bodyPartLocation, clothingItem);
         end
     end


### PR DESCRIPTION
items like belt have no bodypart location in vanilla. default case is not nil, it is '' (empty string). With mods, they can have bodypartLocation and associated visuals.