### PR TITLE
Update PZNS_UtilsNPCs.lua

### DIFF
--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
@@ -80,7 +80,7 @@ function PZNS_UtilsNPCs.PZNS_AddItemsToInventoryNPCSurvivor(npcSurvivor, itemID,
         return;
     end
     --
-    for i = 0, count 
+    for i = 1, count 
     do 
         local item = instanceItem(itemID);
         if (item ~= nil) then


### PR DESCRIPTION
The AddItemsToInventoryNPCSurvivor func previously returned an extra item, setting the initial value of i to 1 prevents this error.