### PR TITLE
Custom speech update

### DIFF
--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
@@ -80,8 +80,8 @@ function PZNS_UtilsNPCs.PZNS_AddItemsToInventoryNPCSurvivor(npcSurvivor, itemID,
         return;
     end
     --
-    for i = 1, count 
-    do 
+    for i = 1, count
+    do
         local item = instanceItem(itemID);
         if (item ~= nil) then
             npcIsoPlayer:getInventory():AddItem(item);
@@ -281,6 +281,32 @@ function PZNS_UtilsNPCs.PZNS_SetNPCFollowTargetID(npcSurvivor, targetID)
     if (targetID) then
         npcSurvivor.followTargetID = targetID;
     end
+end
+
+--- Cows: Assigns a speech table to the npcSurvivor.
+---@param npcSurvivor any
+---@param speechTable table | nil
+function PZNS_UtilsNPCs.PZNS_SetNPCSpeechTable(npcSurvivor, speechTable)
+    if (npcSurvivor == nil) then
+        return;
+    end
+
+    if (speechTable) then
+        npcSurvivor.speechTable = speechTable;
+    end
+end
+
+--- Cows: Have the NPC speak using the input speech table with a specified intention.
+---@param npcSurvivor any
+---@param speechTable table
+---@param intention string | nil
+function PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(npcSurvivor, speechTable, intention)
+    if (npcSurvivor == nil or speechTable == nil) then
+        return;
+    end
+    local tableSize = #speechTable;
+    local rolled = ZombRand(tableSize) + 1;
+    PZNS_NPCSpeak(npcSurvivor, speechTable[rolled], intention);
 end
 
 --- Cows: Clears the queued ISTimedActionQueue

--- a/PZNS_Framework/media/lua/client/03_mod_core/PZNS_NPCSurvivor.lua
+++ b/PZNS_Framework/media/lua/client/03_mod_core/PZNS_NPCSurvivor.lua
@@ -31,11 +31,11 @@ function PZNS_NPCSurvivor:newSurvivor(
         currentAction = "",                     -- Cows: This is a value to check for NPCs to queue or not queue up more actions.
         isStuckTicks = 0,                       -- Cows: This is a value to check if NPC is "stuck" or doing nothing even though it has a job.
         followTargetID = "",                    -- Cows: Used to follow a specified object managed by PZNS IDs
-        speechTable = nil,                      -- WIP - Cows: Likely more useful when custom speech tables are created and mapped to specified NPCs.
+        speechTable = nil,                      -- Cows: Used when adding speech table(s), if nil, NPCs should use PresetsSpeeches instead.
         lastEquippedMeleeWeapon = "",           -- WIP - Cows: Added so that NPCs can resume using this melee weapon after completing an action.
         lastEquippedRangeWeapon = "",           -- WIP - Cows: Added so that NPCs can resume using this range weapon after completing an action.
         idleTicks = 0,                          -- Cows: Used to track how long an NPC is idle for before they take some general AI stuff.
-        actionTicks = 30,                       -- Cows: Need some ticks to control how often the actionQueues are updated... Otherwise the NPCs will continue to queue actions every tick endlessly...
+        actionTicks = 30,                       -- WIP - Cows: Need some ticks to control how often the actionQueues are updated... Otherwise the NPCs will continue to queue actions every tick endlessly...
         attackTicks = 0,                        -- Cows: I thought it was stupid at first, but after observing an NPC queue up 20+ attacks in a a single frame...
         speechTicks = 0,                        -- Cows: Tracks the ticks between speech text... ticks are inconsistent, but there are currently no other short duration timers.
         aimTarget = "",                         -- Cows: Placeholder; technically should always be a game object... but Java API has a "NPCSetAiming()" call which is confusing...

--- a/PZNS_Framework/media/lua/client/03_mod_core/PZNS_NPCSurvivor.lua
+++ b/PZNS_Framework/media/lua/client/03_mod_core/PZNS_NPCSurvivor.lua
@@ -31,7 +31,7 @@ function PZNS_NPCSurvivor:newSurvivor(
         currentAction = "",                     -- Cows: This is a value to check for NPCs to queue or not queue up more actions.
         isStuckTicks = 0,                       -- Cows: This is a value to check if NPC is "stuck" or doing nothing even though it has a job.
         followTargetID = "",                    -- Cows: Used to follow a specified object managed by PZNS IDs
-        speechTableID = nil,                    -- WIP - Cows: Likely more useful when custom speech tables are created and mapped to specified NPCs.
+        speechTable = nil,                      -- WIP - Cows: Likely more useful when custom speech tables are created and mapped to specified NPCs.
         lastEquippedMeleeWeapon = "",           -- WIP - Cows: Added so that NPCs can resume using this melee weapon after completing an action.
         lastEquippedRangeWeapon = "",           -- WIP - Cows: Added so that NPCs can resume using this range weapon after completing an action.
         idleTicks = 0,                          -- Cows: Used to track how long an NPC is idle for before they take some general AI stuff.
@@ -41,6 +41,7 @@ function PZNS_NPCSurvivor:newSurvivor(
         aimTarget = "",                         -- Cows: Placeholder; technically should always be a game object... but Java API has a "NPCSetAiming()" call which is confusing...
         canAttack = true,                       -- Cows: Placeholder; Java API has a "NPCSetAttack()" call which is confusing; as it appears to force the NPC to attack.
         textObject = nil,                       -- Cows: This should handle all the text displayed by the NPC.
+        ------ IsoPlayer Spawning Related below ------
         isAlive = true,                         -- WIP - Technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
         isSpawned = false,                      -- WIP - Technically part of IsoPlayer... but "isExistInTheWorld()" seems very inconsistent...
         forename = "",                          -- Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
@@ -50,8 +51,6 @@ function PZNS_NPCSurvivor:newSurvivor(
         squareY = nil,                          -- Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
         squareZ = nil,                          -- Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
         npcIsoPlayerObject = npcIsoPlayerObject -- Cows: objects cannot be saved to moddata...
-        -- npcHomeZoneID = nil,                    -- Cows: Probably useless, zone ownership are based by groupID for simplified management.
-        -- npcWorkZoneID = nil,                    -- Cows: Probably useless, as a job in a group should go to the designated group work zone.
     };
 
     return npcSurvivor;

--- a/PZNS_Framework/media/lua/client/03_mod_core/PZNS_PresetsSpeeches.lua
+++ b/PZNS_Framework/media/lua/client/03_mod_core/PZNS_PresetsSpeeches.lua
@@ -1,11 +1,51 @@
-PZNS_TemplateSpeechGuard = {
-    r1 = "Understood, I will guard this place.",
-    r2 = "I am now guarding this location...",
-    r3 = "Guard duty huh..."
+-- Cows: Upon further considerations, I think preset speeches should be limited to order and job acknowledgements... for now.
+-- WIP - Cows: So the question is, how can a "personality" be written and added with the current framework?
+local PZNS_PresetsSpeeches = {};
+
+PZNS_PresetsSpeeches.PZNS_OrderConfirmed = {
+    "Whatever you say.",
+    "I'm on it",
+    "Alright"
 };
 
-PZNS_TemplateSpeechCompanion = {
-    r1 = "Understood, Following",
-    r2 = "I got your back",
-    r3 = "Alright, lead the way."
+PZNS_PresetsSpeeches.PZNS_OrderSpeechHoldPosition = {
+    "Understood, I will hold this place.",
+    "I am now holding this location...",
+    "Guard duty huh..."
 };
+
+PZNS_PresetsSpeeches.PZNS_OrderSpeechFollow = {
+    "Understood, Following",
+    "I got your back",
+    "Alright, lead the way."
+};
+
+PZNS_PresetsSpeeches.PZNS_JobSpeechRemoveFromGroup = {
+    "Why me?",
+    "Fine, I'm leaving then",
+    "You'll regret this decision!"
+};
+
+PZNS_PresetsSpeeches.PZNS_JobSpeechIdle = {
+    "I need something to do here...",
+    "What is my next task?",
+    "It's a slow day at work..."
+};
+
+--- Cows: In case a table is used instead of a list. Keep in mind this can be a slow process because it has to count each k-v entry in the table.
+---@param table any
+---@return number
+function PZNS_PresetsSpeeches.PZNS_GetSpeechTableSize(table)
+    local size = 0;
+
+    if (table == nil) then
+        return 0;
+    end
+
+    for _ in pairs(table) do
+        size = size + 1;
+    end
+    return size;
+end
+
+return PZNS_PresetsSpeeches;

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_ManageJobs.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_ManageJobs.lua
@@ -1,5 +1,6 @@
 local PZNS_UtilsDataNPCs = require("02_mod_utils/PZNS_UtilsDataNPCs");
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
+local PZNS_PresetsSpeeches = require("03_mod_core/PZNS_PresetsSpeeches");
 local PZNS_NPCGroupsManager = require("04_data_management/PZNS_NPCGroupsManager");
 --[[
     Cows: The differences between an action, an order, and a job is that an "action" can be queued, rearranged, or cleared as needed.
@@ -36,12 +37,20 @@ function PZNS_UpdateNPCJobRoutine(npcSurvivor)
     end
     -- Cows: Check if the NPC's job is currently "Remove" or "Remove Grom Group".
     if (npcSurvivor.jobName == "Remove" or npcSurvivor.jobName == "Remove From Group") then
-        -- WIP - Cows: Being removed from the group which should make the NPC angry/very angry.
-        PZNS_NPCSpeak(npcSurvivor, "Why me?", "Negative");
+        -- WIP - Cows: Being removed from the group which should make the NPC angry.
+        if (PZNS_UtilsNPCs.PZNS_IsNPCSpeechTableValid(npcSurvivor.speechTable.PZNS_JobSpeechRemoveFromGroup) == true) then
+            PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                npcSurvivor, npcSurvivor.speechTable.PZNS_JobSpeechRemoveFromGroup, "Neutral"
+            );
+        else
+            PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                npcSurvivor, PZNS_PresetsSpeeches.PZNS_JobSpeechRemoveFromGroup, "Neutral"
+            );
+        end
         PZNS_NPCGroupsManager.removeNPCFromGroupBySurvivorID(npcSurvivor.groupID, npcSurvivor.survivorID);
         PZNS_UtilsNPCs.PZNS_SetNPCGroupID(npcSurvivor, nil);
         PZNS_UtilsNPCs.PZNS_SetNPCJob(npcSurvivor, "Guard"); -- WIP - Cows: Currently there is no NPC "wandering" AI nor job... so this is a placeholder
-        return;                                               -- Cows: Stop Processing, the npc is no longer in the group.
+        return;                                              -- Cows: Stop Processing, the npc is no longer in the group.
     end
     -- Cows: Only update living npcSurvivor routine.
     if (npcSurvivor.isAlive == true) then

--- a/PZNS_Framework/media/lua/client/08_mod_contextmenu/PZNS_ContextMenuOrders.lua
+++ b/PZNS_Framework/media/lua/client/08_mod_contextmenu/PZNS_ContextMenuOrders.lua
@@ -1,6 +1,7 @@
 local PZNS_UtilsDataNPCs = require("02_mod_utils/PZNS_UtilsDataNPCs");
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 local PZNS_PlayerUtils = require("02_mod_utils/PZNS_PlayerUtils");
+local PZNS_PresetsSpeeches = require("03_mod_core/PZNS_PresetsSpeeches");
 local PZNS_NPCGroupsManager = require("04_data_management/PZNS_NPCGroupsManager");
 
 PZNS_NPCOrdersText = {
@@ -41,19 +42,47 @@ function PZNS_CreateGroupNPCsSubMenu(parentContextMenu, mpPlayerID, groupID, ord
         local callbackFunction = function()
             -- Cows: Clear the existing queued actions for the npcSurvivor when an Order is issued.
             PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
-            PZNS_NPCSpeak(npcSurvivor, "Order " .. PZNS_NPCOrdersText[orderKey] .. "  acknowledged!", "Friendly");
             local playerSurvivor = getSpecificPlayer(mpPlayerID);
+            playerSurvivor:Say(npcSurvivor.forename .. ", " .. PZNS_NPCOrdersText[orderKey]);
             --
             if (orderKey == "FollowMe" or orderKey == "AimAtMe") then
-                playerSurvivor:Say(npcSurvivor.forename ..
-                    ", " .. PZNS_NPCOrdersText[orderKey] .. ", " .. followTargetID
-                );
+                if (npcSurvivor.speechTable ~= nil) then
+                    if (npcSurvivor.speechTable.PZNS_OrderSpeechFollow) then
+                        PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                            npcSurvivor, npcSurvivor.speechTable.PZNS_OrderSpeechFollow, "Friendly"
+                        );
+                    end
+                else
+                    PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                        npcSurvivor, PZNS_PresetsSpeeches.PZNS_OrderSpeechFollow, "Friendly"
+                    );
+                end
                 PZNS_NPCOrderActions[orderKey](npcSurvivor, followTargetID);
             elseif (orderKey == "HoldPosition") then
-                playerSurvivor:Say(npcSurvivor.forename .. ", " .. PZNS_NPCOrdersText[orderKey]);
+                if (npcSurvivor.speechTable ~= nil) then
+                    if (npcSurvivor.speechTable.PZNS_OrderSpeechHoldPosition) then
+                        PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                            npcSurvivor, npcSurvivor.speechTable.PZNS_OrderSpeechHoldPosition, "Friendly"
+                        );
+                    end
+                else
+                    PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                        npcSurvivor, PZNS_PresetsSpeeches.PZNS_OrderSpeechHoldPosition, "Friendly"
+                    );
+                end
                 PZNS_NPCOrderActions[orderKey](npcSurvivor, square);
             else
-                playerSurvivor:Say(npcSurvivor.forename .. ", " .. PZNS_NPCOrdersText[orderKey]);
+                if (npcSurvivor.speechTable ~= nil) then
+                    if (npcSurvivor.speechTable.PZNS_OrderConfirmed) then
+                        PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                            npcSurvivor, npcSurvivor.speechTable.PZNS_OrderConfirmed, "Friendly"
+                        );
+                    end
+                else
+                    PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                        npcSurvivor, PZNS_PresetsSpeeches.PZNS_OrderConfirmed, "Friendly"
+                    );
+                end
                 PZNS_NPCOrderActions[orderKey](npcSurvivor);
             end
         end

--- a/PZNS_Framework/media/lua/client/10_mod_templates/PZNS_SpeechTableJill.lua
+++ b/PZNS_Framework/media/lua/client/10_mod_templates/PZNS_SpeechTableJill.lua
@@ -1,0 +1,33 @@
+local PZNS_SpeechTableJill = {};
+
+PZNS_SpeechTableJill.PZNS_OrderConfirmed = {
+    "OK",
+    "Got it",
+    "On my way."
+};
+
+PZNS_SpeechTableJill.PZNS_OrderSpeechHoldPosition = {
+    "Understood, I'll be here",
+    "Copy, holding position.",
+    "I'll be over here then."
+};
+
+PZNS_SpeechTableJill.PZNS_OrderSpeechFollow = {
+    "I'm on your six.",
+    "Coming over now.",
+    "Take the point."
+};
+
+PZNS_SpeechTableJill.PZNS_JobSpeechRemoveFromGroup = {
+    "Are you sure? Take care of yourself.",
+    "Look out for those freaks.",
+    "Don't let your guard down."
+};
+
+PZNS_SpeechTableJill.PZNS_JobSpeechIdle = {
+    "We're wasting time here...",
+    "Don't expect me to make a sandwich...",
+    "What should I do next?..."
+};
+
+return PZNS_SpeechTableJill;

--- a/PZNS_Framework/media/lua/client/10_mod_templates/PZNS_TemplateNPCJillTester.lua
+++ b/PZNS_Framework/media/lua/client/10_mod_templates/PZNS_TemplateNPCJillTester.lua
@@ -3,6 +3,7 @@ local PZNS_UtilsDataNPCs = require("02_mod_utils/PZNS_UtilsDataNPCs");
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 local PZNS_NPCGroupsManager = require("04_data_management/PZNS_NPCGroupsManager");
 local PZNS_NPCsManager = require("04_data_management/PZNS_NPCsManager");
+local PZNS_SpeechTableJill = require("10_mod_templates/PZNS_SpeechTableJill");
 
 local npcSurvivorID = "PZNS_JillTester";
 
@@ -30,6 +31,7 @@ function PZNS_SpawnJillTester(mpPlayerID)
             );
             --
             if (npcSurvivor ~= nil) then
+                PZNS_UtilsNPCs.PZNS_SetNPCSpeechTable(npcSurvivor, PZNS_SpeechTableJill);
                 PZNS_UtilsNPCs.PZNS_AddNPCSurvivorPerkLevel(npcSurvivor, "Strength", 5);
                 PZNS_UtilsNPCs.PZNS_AddNPCSurvivorPerkLevel(npcSurvivor, "Fitness", 5);
                 PZNS_UtilsNPCs.PZNS_AddNPCSurvivorPerkLevel(npcSurvivor, "Aiming", 5);


### PR DESCRIPTION
- PZNS_UtilsNPCs.lua
  - Added functions for assigning speech tables to NPC
  - Added function for using speech table 
- PZNS_NPCSurvivor.lua
  - Updated comments
  - Replaced 'speechTableID' with 'speechTable'  
- PZNS_PresetsSpeeches.lua
  - Revamped the preset speech tables based on orders and job(s)  
  - This should make it easier to understand the context and organize NPC Speeches.
-PZNS_ManageJobs.lua  
  - Now uses speech table functions as mentioned above
-  PZNS_ContextMenuOrders.lua
  - Now uses speech table functions as mentioned above
- PZNS_SpeechTableJill.lua
  - Added basic speech tables based on the above functions and structure
- PZNS_TemplateNPCJillTester.lua
  - Assigned a speech table for testing.