### PR TITLE
Steamlined NPC Checking

### DIFF
--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
@@ -347,7 +347,7 @@ function PZNS_UtilsNPCs.PZNS_GetNPCActionsQueuedCount(npcSurvivor)
         return;
     end
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
-    local actionsCount =  #ISTimedActionQueue.getTimedActionQueue(npcIsoPlayer.queue);
+    local actionsCount = #ISTimedActionQueue.getTimedActionQueue(npcIsoPlayer.queue);
     return actionsCount;
 end
 
@@ -529,6 +529,18 @@ function PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor)
         npcSurvivor.isStuckTicks = npcSurvivor.isStuckTicks + 1;
     end
     PZNS_NPCSpeak(npcSurvivor, "isStuckTicks: " .. tostring(npcSurvivor.isStuckTicks), "InfoOnly");
+end
+
+--- Cows: This is to streamline the multiple npcIsoPlayerObject checks...
+function PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor)
+    if (npcSurvivor == nil) then
+        return false;
+    end
+    local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
+    if (npcIsoPlayer == nil) then
+        return false;
+    end
+    return true;
 end
 
 return PZNS_UtilsNPCs;

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_DropItem.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_DropItem.lua
@@ -4,8 +4,11 @@ local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 ---@param npcSurvivor any
 ---@param targetItem any
 function PZNS_DropItem(npcSurvivor, targetItem)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return;
+    end
     --
-    if (npcSurvivor == nil or targetItem == nil) then
+    if (targetItem == nil) then
         return;
     end
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
@@ -15,5 +18,5 @@ function PZNS_DropItem(npcSurvivor, targetItem)
             targetItem,
             50 -- Cows: This seems to be a delay for animation?
         );
-        PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, dropAction);
+    PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, dropAction);
 end

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_EnterVehicle.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_EnterVehicle.lua
@@ -4,24 +4,27 @@ local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 ---@param npcSurvivor any
 ---@param targetIsoPlayer any
 function PZNS_EnterVehicleAsPassenger(npcSurvivor, targetIsoPlayer)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return;
+    end
+    -- Cows: Check if the npc is alive.
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
+    if (npcIsoPlayer:isAlive() == false) then
+        return;
+    end
+    -- Cows: Now get the vehicle and the seats it has.
     local driverVehicle = targetIsoPlayer:getVehicle();
     -- local driverSeat = driverVehicle:getSeat(targetIsoPlayer);
     local numOfSeats = driverVehicle:getScript():getPassengerCount();
-
-    if (npcIsoPlayer) then
-        if (npcIsoPlayer:isAlive() == true) then
-            -- Cows: Enter the first available seat that is not the driver seat.
-            for i = 1, numOfSeats do
-                --
-                if (driverVehicle:isSeatOccupied(i) ~= true) then
-                    local enterCarAction = ISEnterVehicle:new(npcIsoPlayer, driverVehicle, i);
-                    local closeCarDoorAction = ISCloseVehicleDoor:new(npcIsoPlayer, driverVehicle, i);
-                    PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, enterCarAction);
-                    PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, closeCarDoorAction);
-                    break;
-                end
-            end
+    -- Cows: Enter the first available seat that is not the driver seat.
+    for i = 1, numOfSeats do
+        --
+        if (driverVehicle:isSeatOccupied(i) ~= true) then
+            local enterCarAction = ISEnterVehicle:new(npcIsoPlayer, driverVehicle, i);
+            local closeCarDoorAction = ISCloseVehicleDoor:new(npcIsoPlayer, driverVehicle, i);
+            PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, enterCarAction);
+            PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, closeCarDoorAction);
+            break;
         end
     end
 end
@@ -29,14 +32,15 @@ end
 ---comment
 ---@param npcSurvivor any
 function PZNS_ExitVehicle(npcSurvivor)
-    local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
-    if (npcIsoPlayer) then
-        local currentVehicle = npcIsoPlayer:getVehicle();
-        local currentSeat = npcIsoPlayer:getVehicle():getSeat(npcIsoPlayer);
-        --
-        local exitCarAction = ISExitVehicle:new(npcIsoPlayer);
-        local closeCarDoorAction = ISCloseVehicleDoor:new(npcIsoPlayer, currentVehicle, currentSeat);
-        PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, exitCarAction);
-        PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, closeCarDoorAction);
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return;
     end
+    --
+    local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
+    local currentVehicle = npcIsoPlayer:getVehicle();
+    local currentSeat = npcIsoPlayer:getVehicle():getSeat(npcIsoPlayer);
+    local exitCarAction = ISExitVehicle:new(npcIsoPlayer);
+    local closeCarDoorAction = ISCloseVehicleDoor:new(npcIsoPlayer, currentVehicle, currentSeat);
+    PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, exitCarAction);
+    PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, closeCarDoorAction);
 end

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_GrabCorpse.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_GrabCorpse.lua
@@ -5,7 +5,7 @@ local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 ---@param targetBody any
 function PZNS_GrabCorpse(npcSurvivor, targetBody)
     --
-    if (npcSurvivor == nil or targetBody == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false or targetBody == nil) then
         return;
     end
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_GrabCorpse.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_GrabCorpse.lua
@@ -1,6 +1,6 @@
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 
----comment
+--- WIP - Cows: Errors are throw while grabbing a corpse, seems related to forced Equip/Unequip weapons when a heavy object is carried...
 ---@param npcSurvivor any
 ---@param targetBody any
 function PZNS_GrabCorpse(npcSurvivor, targetBody)

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_GunMagazine.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_GunMagazine.lua
@@ -3,21 +3,22 @@ local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 --- Cows: Eject clip/magazine from gun.
 ---@param npcSurvivor any
 function PZNS_GunMagazineEject(npcSurvivor)
-    if (npcSurvivor == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     ---@type HandWeapon
     local npcHandItem = npcIsoPlayer:getPrimaryHandItem();
     --
-    if (npcHandItem ~= nil) then
-        if (npcHandItem:IsWeapon() == true and npcHandItem:isRanged() == true) then
-            if (npcHandItem:isContainsClip()) then
-                -- Cows: This is a modified copy from 'ISReloadWeaponAction.BeginAutomaticReload'
-                local ejectMagAction = ISEjectMagazine:new(npcIsoPlayer, npcHandItem);
-                PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, ejectMagAction);
-                return ejectMagAction;
-            end
+    if (npcHandItem == nil) then
+        return;
+    end
+    if (npcHandItem:IsWeapon() == true and npcHandItem:isRanged() == true) then
+        if (npcHandItem:isContainsClip()) then
+            -- Cows: This is a modified copy from 'ISReloadWeaponAction.BeginAutomaticReload'
+            local ejectMagAction = ISEjectMagazine:new(npcIsoPlayer, npcHandItem);
+            PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, ejectMagAction);
+            return ejectMagAction;
         end
     end
 end
@@ -25,20 +26,23 @@ end
 --- Cows: Reload by inserting ammo into clip/magazine.
 ---@param npcSurvivor any
 function PZNS_GunMagazineReload(npcSurvivor)
-    if (npcSurvivor == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
     --
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     ---@type HandWeapon
     local npcHandItem = npcIsoPlayer:getPrimaryHandItem();
-    local bullets = 0;
-    local count = 0;
+    if (npcHandItem == nil) then
+        return;
+    end
     --
     if (npcHandItem:IsWeapon() == true and npcHandItem:isRanged() == true) then
         local npc_inventory = npcIsoPlayer:getInventory();
         local magazine = npc_inventory:getFirstTypeRecurse(npcHandItem:getMagazineType());
         local ammoType = npcHandItem:getAmmoType();
+        local bullets = 0;
+        local count = 0;
         --
         if ammoType then
             bullets = npc_inventory:getItemCountRecurse(ammoType);
@@ -62,12 +66,15 @@ end
 --- Cows: Insert clip/magazine into gun.
 ---@param npcSurvivor any
 function PZNS_GunMagazineInsert(npcSurvivor)
-    if (npcSurvivor == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
     --
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     local npcHandItem = npcIsoPlayer:getPrimaryHandItem();
+    if (npcHandItem == nil) then
+        return;
+    end
     -- Cows: This function looks for the magazine with the most ammo in it and inserts it into the current gun.
     if (npcHandItem:IsWeapon() == true and npcHandItem:isRanged() == true) then
         local magazine = npcHandItem:getBestMagazine(npcIsoPlayer);

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_RunTo.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_RunTo.lua
@@ -131,7 +131,7 @@ end
 ---@param squareY any
 ---@param squareZ any
 function PZNS_RunToSquareXYZ(npcSurvivor, squareX, squareY, squareZ)
-    if (npcSurvivor == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WalkTo.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WalkTo.lua
@@ -6,8 +6,8 @@ local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 ---@param squareY any
 ---@param squareZ any
 function PZNS_WalkToSquareXYZ(npcSurvivor, squareX, squareY, squareZ)
-    if (npcSurvivor == nil) then
-        return nil;
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return;
     end
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     local targetSquare = getCell():getGridSquare(

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WashClothing.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WashClothing.lua
@@ -5,58 +5,61 @@ local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 ---@param targetItem IsoObject
 ---@param soapList any
 function PZNS_WashClothing(npcSurvivor, targetItem, soapList)
-    if (npcSurvivor == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
+    --
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     local inventoryItems = npcIsoPlayer:getInventory():getItems();
+    if (inventoryItems == nil) then
+        return;
+    end
+    --
     local waterRemaining = targetItem:getWaterAmount();
     local soapRemaining = ISWashClothing.GetSoapRemaining(soapList);
     --
-    if (inventoryItems) then
+    for i = 0, inventoryItems:size() - 1 do
+        local currentItem = inventoryItems:get(i);
+        local bloodAmount = 0;
+        local dirtAmount = 0;
         --
-        for i = 0, inventoryItems:size() - 1 do
-            local currentItem = inventoryItems:get(i);
-            local bloodAmount = 0;
-            local dirtAmount = 0;
-            --
-            if instanceof(currentItem, "Clothing") then
-                if BloodClothingType.getCoveredParts(currentItem:getBloodClothingType()) then
-                    local coveredParts = BloodClothingType.getCoveredParts(currentItem:getBloodClothingType());
-                    --
-                    for j = 0, coveredParts:size() - 1 do
-                        local thisPart = coveredParts:get(j)
-                        bloodAmount = bloodAmount + currentItem:getBlood(thisPart);
-                    end
-                end
+        if instanceof(currentItem, "Clothing") then
+            if BloodClothingType.getCoveredParts(currentItem:getBloodClothingType()) then
+                local coveredParts = BloodClothingType.getCoveredParts(currentItem:getBloodClothingType());
                 --
-                if currentItem:getDirtyness() > 0 then
-                    dirtAmount = dirtAmount + currentItem:getDirtyness();
+                for j = 0, coveredParts:size() - 1 do
+                    local thisPart = coveredParts:get(j)
+                    bloodAmount = bloodAmount + currentItem:getBlood(thisPart);
                 end
-            elseif instanceof(currentItem, "Weapon") then
-                bloodAmount = bloodAmount + currentItem:getBloodLevel();
             end
+            --
+            if currentItem:getDirtyness() > 0 then
+                dirtAmount = dirtAmount + currentItem:getDirtyness();
+            end
+        elseif instanceof(currentItem, "Weapon") then
+            bloodAmount = bloodAmount + currentItem:getBloodLevel();
+        end
 
-            if (bloodAmount > 0 or dirtAmount > 0) then
-                if waterRemaining > ISWashClothing.GetRequiredWater(currentItem) then
-                    waterRemaining = waterRemaining - ISWashClothing.GetRequiredWater(currentItem);
-                    local noSoap = true
-                    if soapRemaining > ISWashClothing.GetRequiredSoap(currentItem) then
-                        soapRemaining = soapRemaining - ISWashClothing.GetRequiredSoap(currentItem);
-                        noSoap = false;
-                    end
-                    local washAction =
-                        ISWashClothing:new(
-                            npcIsoPlayer,
-                            targetItem,
-                            soapList,
-                            currentItem,
-                            bloodAmount,
-                            dirtAmount,
-                            noSoap
-                        );
-                        PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, washAction);
+        if (bloodAmount > 0 or dirtAmount > 0) then
+            if waterRemaining > ISWashClothing.GetRequiredWater(currentItem) then
+                waterRemaining = waterRemaining - ISWashClothing.GetRequiredWater(currentItem);
+                --
+                local noSoap = true;
+                if soapRemaining > ISWashClothing.GetRequiredSoap(currentItem) then
+                    soapRemaining = soapRemaining - ISWashClothing.GetRequiredSoap(currentItem);
+                    noSoap = false;
                 end
+                local washAction =
+                    ISWashClothing:new(
+                        npcIsoPlayer,
+                        targetItem,
+                        soapList,
+                        currentItem,
+                        bloodAmount,
+                        dirtAmount,
+                        noSoap
+                    );
+                PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, washAction);
             end
         end
     end

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WashSelf.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WashSelf.lua
@@ -5,11 +5,11 @@ local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 ---@param targetItem IsoObject
 ---@param soapList any
 function PZNS_WashSelf(npcSurvivor, targetItem, soapList)
-    if (npcSurvivor == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
+    --
     local washAction = ISWashYourself:new(npcIsoPlayer, targetItem, soapList);
-
     PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, washAction);
 end

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponAiming.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponAiming.lua
@@ -1,4 +1,5 @@
 local PZNS_CombatUtils = require("02_mod_utils/PZNS_CombatUtils");
+local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 local PZNS_WorldUtils = require("02_mod_utils/PZNS_WorldUtils");
 
 local spottingRange = 30; -- Cows: Perhaps a user option in the future...
@@ -6,46 +7,52 @@ local spottingRange = 30; -- Cows: Perhaps a user option in the future...
 ---comment
 ---@param npcSurvivor any
 function PZNS_WeaponAiming(npcSurvivor)
-    --
-    if (npcSurvivor == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
     --
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
+    -- Cows: Check if the NPC has an item in hand
+    local npcWeapon = npcIsoPlayer:getPrimaryHandItem();
+    if (npcWeapon == nil) then
+        return;
+    end
+    if (npcWeapon:IsWeapon() ~= true) then
+        return;
+    end
+    -- Cows: Check if the entity the NPC is aiming at exists
     local targetObject = npcSurvivor.aimTarget;
+    if (targetObject == nil) then
+        return;
+    end
+    -- Cows: Check if the target is valid to be damaged.
+    if (PZNS_CombatUtils.PZNS_IsTargetInvalidForDamage(targetObject) == true) then
+        npcIsoPlayer:NPCSetAiming(false);
+        return;
+    end
+    -- Cows: Get all check values for the NPC before said NPC can aim.
+    local distanceFromTarget = PZNS_WorldUtils.PZNS_GetDistanceBetweenTwoObjects(npcIsoPlayer, targetObject);
+    local canSeeTarget = npcIsoPlayer:CanSee(targetObject); -- Cows: "vision cone" isn't a thing for NPCs... they can "see" the world objects without facing them.
+    local isTargetAlive = targetObject:isAlive();
+    local isTargetInSpottingRange = distanceFromTarget < spottingRange;
+    local aimRange = npcWeapon:getMaxRange();
+    local isTargetInAimRange = distanceFromTarget < aimRange;
     --
-    if (targetObject ~= nil) then
-        -- Cows: Check if the entity the NPC is aiming at exists
-        if (PZNS_CombatUtils.PZNS_IsTargetInvalidForDamage(targetObject) == true) then
-            npcIsoPlayer:NPCSetAiming(false);
-            return;
+    if (
+            isTargetAlive == true
+            and canSeeTarget == true
+            and isTargetInSpottingRange == true
+        )
+    then
+        npcIsoPlayer:faceThisObject(targetObject);
+        --
+        if (isTargetInAimRange == true) then
+            npcIsoPlayer:NPCSetAiming(true);
         else
-            -- Cows: Need to add a "Vision" check for hostiles before aiming...
-            local distanceFromTarget = PZNS_WorldUtils.PZNS_GetDistanceBetweenTwoObjects(npcIsoPlayer, targetObject);
-            local canSeeTarget = npcIsoPlayer:CanSee(targetObject); -- Cows: "vision cone" isn't a thing for NPCs... they can "see" the world objects without facing them.
-            local isTargetAlive = targetObject:isAlive();
-            local isTargetInSpottingRange = distanceFromTarget < spottingRange;
-            --
-            local aimRange = npcIsoPlayer:getPrimaryHandItem():getMaxRange();
-            local isTargetInAimRange = distanceFromTarget < aimRange;
-            --
-            if (
-                    isTargetAlive == true
-                    and canSeeTarget == true
-                    and isTargetInSpottingRange == true
-                )
-            then
-                npcIsoPlayer:faceThisObject(targetObject);
-                --
-                if (isTargetInAimRange == true) then
-                    npcIsoPlayer:NPCSetAiming(true);
-                else
-                    npcIsoPlayer:NPCSetAiming(false);
-                end
-            else
-                npcSurvivor.aimTarget = nil;
-                npcIsoPlayer:NPCSetAiming(false);
-            end
+            npcIsoPlayer:NPCSetAiming(false);
         end
+    else
+        npcSurvivor.aimTarget = nil;
+        npcIsoPlayer:NPCSetAiming(false);
     end
 end

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponReload.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponReload.lua
@@ -2,16 +2,15 @@ local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 ---comment
 ---@param npcSurvivor any
 function PZNS_WeaponReload(npcSurvivor)
-    if (npcSurvivor == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
-    if (npcIsoPlayer == nil) then
+    local npcHandItem = npcIsoPlayer:getPrimaryHandItem();
+    if (npcHandItem == nil) then
         return;
     end
-    local npcHandItem = npcIsoPlayer:getPrimaryHandItem();
-    local magazineType = npcHandItem:getMagazineType();
-
+    --
     if (npcIsoPlayer:NPCGetAiming() == true) then
         npcIsoPlayer:NPCSetAiming(false);
     end
@@ -22,6 +21,7 @@ function PZNS_WeaponReload(npcSurvivor)
     local actionQueue = ISTimedActionQueue.getTimedActionQueue(npcIsoPlayer);
     local lastAction = actionQueue.queue[#actionQueue.queue];
     -- Cows: Magazine based reload
+    local magazineType = npcHandItem:getMagazineType();
     if (magazineType ~= nil) then
         -- Cows: If there are more than 3 actions queued, reset the queue so the NPC can start reloading right away.
         if (actionsCount > 3) then

--- a/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_AttackTarget.lua
+++ b/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_AttackTarget.lua
@@ -5,6 +5,5 @@ function PZNS_AttackTarget(npcSurvivor)
     if (npcSurvivor == nil) then
         return;
     end
-    --
     npcSurvivor.canAttack = true;
 end

--- a/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_HoldPosition.lua
+++ b/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_HoldPosition.lua
@@ -1,9 +1,10 @@
+local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
+
 ---comment
 ---@param npcSurvivor any
 ---@param targetSquare IsoGridSquare
 function PZNS_HoldPosition(npcSurvivor, targetSquare)
-    --
-    if (npcSurvivor == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
     --

--- a/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_MoveToDropItem.lua
+++ b/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_MoveToDropItem.lua
@@ -6,7 +6,7 @@ local PZNS_WorldUtils = require("02_mod_utils/PZNS_WorldUtils");
 ---@param square IsoGridSquare
 ---@param itemToDrop IsoObject
 function PZNS_MoveToDropItem(npcSurvivor, square, itemToDrop)
-    if (npcSurvivor == nil or square == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false or square == nil) then
         return;
     end
     --

--- a/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_MoveToGrabCorpse.lua
+++ b/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_MoveToGrabCorpse.lua
@@ -6,7 +6,7 @@ local PZNS_WorldUtils = require("02_mod_utils/PZNS_WorldUtils");
 ---@param square IsoGridSquare
 ---@param deadBody IsoDeadBody
 function PZNS_MoveToGrabCorpse(npcSurvivor, square, deadBody)
-    if (npcSurvivor == nil or square == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false or square == nil) then
         return;
     end
     --

--- a/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_NPCNeeds.lua
+++ b/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_NPCNeeds.lua
@@ -1,3 +1,5 @@
+local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
+
 function PZNS_DrinkWater(npcSurvivor)
     --
     if (npcSurvivor == nil) then
@@ -51,7 +53,6 @@ function PZNS_WashClothesAtSquare(npcSurvivor, targetSquare)
     end
     --
     npcSurvivor.aimTarget = nil;
-    npcSurvivor.isHoldingInPlace = true;
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     local squareObjects = targetSquare:getObjects();
     local objectsListSize = squareObjects:size() - 1;
@@ -76,15 +77,12 @@ end
 ---@param npcSurvivor any
 ---@param targetSquare IsoGridSquare
 function PZNS_WashSelfAtSquare(npcSurvivor, targetSquare)
-    --
-    if (npcSurvivor == nil or targetSquare == nil) then
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false or targetSquare == nil) then
         return;
     end
     --
     npcSurvivor.aimTarget = nil;
-    npcSurvivor.isHoldingInPlace = true;
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
-    --
     local squareObjects = targetSquare:getObjects();
     local objectsListSize = squareObjects:size() - 1;
     --

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
@@ -13,6 +13,9 @@ local PZNS_GeneralAI = {};
 ---@param npcSurvivor any
 ---@return boolean
 function PZNS_GeneralAI.PZNS_IsReloadNeeded(npcSurvivor)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return false;
+    end
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     -- Cows: Can only if npcSurvivor is Alive.
     if (npcIsoPlayer:isAlive() == true) then
@@ -56,6 +59,9 @@ end
 ---@param npcSurvivor any
 ---@return boolean
 function PZNS_GeneralAI.PZNS_CanSeeAimTarget(npcSurvivor)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return false;
+    end
     --
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     if (npcIsoPlayer) then
@@ -75,6 +81,9 @@ end
 --- Cows: Have the NPC aim and attack their aimed target.
 ---@param npcSurvivor any
 function PZNS_GeneralAI.PZNS_NPCAimAttack(npcSurvivor)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return false;
+    end
     ---@type IsoPlayer
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     if (npcIsoPlayer) then
@@ -92,6 +101,9 @@ end
 ---@param npcSurvivor any
 ---@return boolean
 function PZNS_GeneralAI.PZNS_NPCFoundThreat(npcSurvivor)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return false;
+    end
     -- Cows: Check if threat is in sight.
     local isThreatInSight = PZNS_GeneralAI.PZNS_CanSeeAimTarget(npcSurvivor);
     -- Cows: check if any threats are found.
@@ -111,6 +123,9 @@ end
 ---@param npcSurvivor any
 ---@return boolean
 function PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return false;
+    end
     -- Cows: action ticks can go over 200 if the reload action was interrupted midway.
     if (npcSurvivor.actionTicks > 200) then
         npcSurvivor.actionTicks = 0;

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
@@ -55,7 +55,7 @@ function PZNS_GeneralAI.PZNS_IsReloadNeeded(npcSurvivor)
     return false;
 end
 
----comment
+--- WIP - Cows: Perhaps this needs a distance check as well? Apparently NPCs can "see" more than 30 squares away (or off-screen).
 ---@param npcSurvivor any
 ---@return boolean
 function PZNS_GeneralAI.PZNS_CanSeeAimTarget(npcSurvivor)
@@ -64,12 +64,16 @@ function PZNS_GeneralAI.PZNS_CanSeeAimTarget(npcSurvivor)
     end
     --
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
-    if (npcIsoPlayer) then
-        -- Cows: Can only see if npcSurvivor is Alive.
-        if (npcIsoPlayer:isAlive() == true) then
-            --
-            if (PZNS_WorldUtils.PZNS_IsObjectZombieActive(npcSurvivor.aimTarget) == true) then
-                local canSeeTarget = npcIsoPlayer:CanSee(npcSurvivor.aimTarget); -- Cows: "vision cone" isn't a thing for NPCs... they can "see" the world objects without facing them.
+    -- Cows: Can only see if npcSurvivor is Alive.
+    if (npcIsoPlayer:isAlive() == true) then
+        --
+        if (PZNS_WorldUtils.PZNS_IsObjectZombieActive(npcSurvivor.aimTarget) == true) then
+            local distanceFromTarget = PZNS_WorldUtils.PZNS_GetDistanceBetweenTwoObjects(
+                npcIsoPlayer,
+                npcSurvivor.aimTarget
+            );
+            if (distanceFromTarget <= 30) then
+                local canSeeTarget = npcIsoPlayer:CanSee(npcSurvivor.aimTarget);     -- Cows: "vision cone" isn't a thing for NPCs... they can "see" the world objects without facing them.
                 return canSeeTarget;
             end
         end
@@ -108,12 +112,14 @@ function PZNS_GeneralAI.PZNS_NPCFoundThreat(npcSurvivor)
     local isThreatInSight = PZNS_GeneralAI.PZNS_CanSeeAimTarget(npcSurvivor);
     -- Cows: check if any threats are found.
     if (isThreatInSight == true) then
+        -- PZNS_NPCSpeak(npcSurvivor, "Threat is in Sight! Now Busy in combat", "InfoOnly");
         return true;
     end
     -- Cows: Check for other threats
     local isThreatFound = PZNS_CheckZombieThreat(npcSurvivor);
     -- Cows: check if any threats are found.
     if (isThreatFound == true) then
+        -- PZNS_NPCSpeak(npcSurvivor, "Threat Found! Now Busy in combat", "InfoOnly");
         return true;
     end
     return false;

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
@@ -1,3 +1,4 @@
+local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 local PZNS_GeneralAI = require("07_npc_ai/PZNS_GeneralAI");
 --
 local followRange = 3;
@@ -7,8 +8,8 @@ local idleActionOnTick = 200;
 ---comment
 ---@param npcSurvivor any
 function PZNS_JobGuard(npcSurvivor)
-    if (npcSurvivor == nil) then
-        return nil;
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return;
     end
     if (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
         npcSurvivor.idleTicks = 0;

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobUndertaker.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobUndertaker.lua
@@ -56,19 +56,23 @@ local function checkCellForCorpseSquares()
     return cellCorpseSquares;
 end
 
----comment
+--- Cows: Only render if the grab square is not nil and on screen.
 local function renderGrabSquare()
     if (debugGrabSquare ~= nil) then
-        debugGrabSquare:getFloor():setHighlightColor(PZNS_ZoneColors["ZoneDropCorpsesColor"]);
-        debugGrabSquare:getFloor():setHighlighted(true);
+        if (debugGrabSquare:IsOnScreen()) then
+            debugGrabSquare:getFloor():setHighlightColor(PZNS_ZoneColors["ZoneDropCorpsesColor"]);
+            debugGrabSquare:getFloor():setHighlighted(true);
+        end
     end
 end
 
----comment
+--- Cows: Only render if the drop square is not nil and on screen.
 local function renderDropSquare()
     if (debugDropSquare ~= nil) then
-        debugDropSquare:getFloor():setHighlightColor(PZNS_ZoneColors["ZoneDropCorpsesColor"]);
-        debugDropSquare:getFloor():setHighlighted(true);
+        if (debugDropSquare:IsOnScreen()) then
+            debugDropSquare:getFloor():setHighlightColor(PZNS_ZoneColors["ZoneDropCorpsesColor"]);
+            debugDropSquare:getFloor():setHighlighted(true);
+        end
     end
 end
 

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobUndertaker.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobUndertaker.lua
@@ -75,9 +75,8 @@ end
 ---comment
 ---@param npcSurvivor any
 function PZNS_JobUndertaker(npcSurvivor)
-    --
-    if (npcSurvivor == nil) then
-        return nil;
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return;
     end
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     local groupDropSquare = PZNS_UtilsZones.PZNS_CheckGroupWorkZoneExists(npcSurvivor.groupID, "ZoneDropCorpses");

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobsCompanion.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobsCompanion.lua
@@ -115,66 +115,67 @@ end
 ---@param npcSurvivor any
 ---@param targetID string
 function PZNS_JobCompanion(npcSurvivor, targetID)
-    if (npcSurvivor == nil) then
-        return nil;
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return;
     end
     --
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     local targetIsoPlayer = getTargetIsoPlayerByID(targetID);
     --
-    if (npcIsoPlayer and targetIsoPlayer) then
-        -- Cows: Check if npcSurvivor is not holding in place
-        if (npcSurvivor.isHoldingInPlace ~= true) then
-            local isTargetInCar = targetIsoPlayer:getVehicle();
-            local isSelfInCar = npcIsoPlayer:getVehicle();
-            -- Cows: Check if target is in a car and if npcSurvivor is not in a car.
-            if (isTargetInCar ~= nil and isSelfInCar == nil) then
-                npcSurvivor.idleTicks = 0;
-                jobCompanion_EnterCar(npcSurvivor, targetIsoPlayer);
-                -- Cows: Else check if npcSurvivor and follow target are both in a car
-            elseif (isTargetInCar ~= nil and isSelfInCar ~= nil) then
-                -- WIP - Cows: perhaps NPCs can attack hostiles while in the car with a gun?...
-                npcSurvivor.idleTicks = 0;
+    if (targetIsoPlayer == nil) then
+        return;
+    end
+    -- Cows: Check if npcSurvivor is not holding in place
+    if (npcSurvivor.isHoldingInPlace ~= true) then
+        local isTargetInCar = targetIsoPlayer:getVehicle();
+        local isSelfInCar = npcIsoPlayer:getVehicle();
+        -- Cows: Check if target is in a car and if npcSurvivor is not in a car.
+        if (isTargetInCar ~= nil and isSelfInCar == nil) then
+            npcSurvivor.idleTicks = 0;
+            jobCompanion_EnterCar(npcSurvivor, targetIsoPlayer);
+            -- Cows: Else check if npcSurvivor and follow target are both in a car
+        elseif (isTargetInCar ~= nil and isSelfInCar ~= nil) then
+            -- WIP - Cows: perhaps NPCs can attack hostiles while in the car with a gun?...
+            npcSurvivor.idleTicks = 0;
 
-                -- Cows: Check if target is NOT in a car and exit the car if self is in one.
-            elseif (isTargetInCar == nil and isSelfInCar ~= nil) then
-                PZNS_ExitVehicle(npcSurvivor);
-            else -- Cows: Else assume both npcSurvivor and target are on foot.
-                -- Cows: Companion is currently being forced to move, presumably to keep up with the target.
-                if (npcSurvivor.isForcedMoving == true) then
-                    npcSurvivor.idleTicks = 0;
-                    jobCompanion_Movement(npcSurvivor, targetIsoPlayer);
-                    return; -- Cows: Stop processing and start moving to target.
-                end
-
-                local canSeeTarget = npcIsoPlayer:CanSee(targetIsoPlayer);
-                -- Cows: Check if npcSurvivor is NOT near their follow target...
-                if (isCompanionInFollowRange(npcIsoPlayer, targetIsoPlayer) == false or canSeeTarget == false) then
-                    npcSurvivor.idleTicks = 0;
-                    jobCompanion_Movement(npcSurvivor, targetIsoPlayer);
-                    return; -- Cows: Stop processing and start moving to target.
-                    -- Cows: Else Check if the NPC is busy in combat related stuff.
-                elseif (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
-                    npcSurvivor.idleTicks = 0;
-                    return; -- Cows Stop Processing and let the NPC finish its actions.
-                end
-                --Cows: Check if companion has idled for too long and take action.
-                if (npcSurvivor.idleTicks >= CompanionIdleTicks) then
-                    -- Cows: Do Idle stuff, eat, wash, read books?
-                    -- PZNS_NPCSpeak(npcSurvivor,
-                    --     "I am getting bored here... idleTicks: " .. tostring(npcSurvivor.idleTicks), "InfoOnly"
-                    -- );
-                else
-                    npcSurvivor.isForcedMoving = false;
-                    npcSurvivor.idleTicks = npcSurvivor.idleTicks + 1;
-                end
-            end
-        else
-            -- Cows: else assume the npcSurvivor is holding in place.
-            if (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
+            -- Cows: Check if target is NOT in a car and exit the car if self is in one.
+        elseif (isTargetInCar == nil and isSelfInCar ~= nil) then
+            PZNS_ExitVehicle(npcSurvivor);
+        else     -- Cows: Else assume both npcSurvivor and target are on foot.
+            -- Cows: Companion is currently being forced to move, presumably to keep up with the target.
+            if (npcSurvivor.isForcedMoving == true) then
                 npcSurvivor.idleTicks = 0;
-                return; -- Cows Stop Processing and let the NPC finish its actions.
+                jobCompanion_Movement(npcSurvivor, targetIsoPlayer);
+                return;     -- Cows: Stop processing and start moving to target.
             end
+
+            local canSeeTarget = npcIsoPlayer:CanSee(targetIsoPlayer);
+            -- Cows: Check if npcSurvivor is NOT near their follow target...
+            if (isCompanionInFollowRange(npcIsoPlayer, targetIsoPlayer) == false or canSeeTarget == false) then
+                npcSurvivor.idleTicks = 0;
+                jobCompanion_Movement(npcSurvivor, targetIsoPlayer);
+                return;     -- Cows: Stop processing and start moving to target.
+                -- Cows: Else Check if the NPC is busy in combat related stuff.
+            elseif (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
+                npcSurvivor.idleTicks = 0;
+                return;     -- Cows Stop Processing and let the NPC finish its actions.
+            end
+            --Cows: Check if companion has idled for too long and take action.
+            if (npcSurvivor.idleTicks >= CompanionIdleTicks) then
+                -- Cows: Do Idle stuff, eat, wash, read books?
+                -- PZNS_NPCSpeak(npcSurvivor,
+                --     "I am getting bored here... idleTicks: " .. tostring(npcSurvivor.idleTicks), "InfoOnly"
+                -- );
+            else
+                npcSurvivor.isForcedMoving = false;
+                npcSurvivor.idleTicks = npcSurvivor.idleTicks + 1;
+            end
+        end
+    else
+        -- Cows: else assume the npcSurvivor is holding in place.
+        if (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
+            npcSurvivor.idleTicks = 0;
+            return;     -- Cows Stop Processing and let the NPC finish its actions.
         end
     end
 end


### PR DESCRIPTION
PZNS_UtilsNPCs
- Added PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor)  
- All functions checking for both '__npcSurvivor__' and '__npcIsoPlayerObject__' should now use the above functions to verify both variables are valid.  

PZNS_GeneralAI
- Added a distance check (<= 30 squares) as to when a threat can be detected.
- This will need another look in the future.

PZNS_JobUndertaker 
- DebugSquares will now only render while on screen
- Known Issue: when NPCs are grabbing a corpse, an error is thrown due to equip/unequip actions(?) needs more investigation later.

