### PR TITLE
Jobs Update

### DIFF
--- a/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_Follow.lua
+++ b/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_Follow.lua
@@ -10,4 +10,5 @@ function PZNS_Follow(npcSurvivor, targetID)
     npcSurvivor.isHoldingInPlace = false;
     npcSurvivor.jobName = "Companion";
     npcSurvivor.followTargetID = targetID;
+    npcSurvivor.jobSquare = nil;
 end

--- a/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_HoldPosition.lua
+++ b/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_HoldPosition.lua
@@ -26,6 +26,7 @@ function PZNS_HoldPosition(npcSurvivor, targetSquare)
             or npcSquareZ ~= targetZ
         )
     then
+        npcSurvivor.jobSquare = targetSquare;
         PZNS_RunToSquareXYZ(npcSurvivor, targetX, targetY, targetZ); -- WIP - Cows: NPCs don't actually run... still only walks for whatever reason.
     end
 end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
@@ -1,10 +1,8 @@
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
+local PZNS_UtilsZones = require("02_mod_utils/PZNS_UtilsZones");
+local PZNS_WorldUtils = require("02_mod_utils/PZNS_WorldUtils");
 local PZNS_GeneralAI = require("07_npc_ai/PZNS_GeneralAI");
 --
-local followRange = 3;
-local runRange = 5;
-local idleActionOnTick = 200;
-
 ---comment
 ---@param npcSurvivor any
 function PZNS_JobGuard(npcSurvivor)
@@ -15,9 +13,95 @@ function PZNS_JobGuard(npcSurvivor)
         npcSurvivor.idleTicks = 0;
         return; -- Cows Stop Processing and let the NPC finish its actions.
     end
-    -- Cows: Have the guard patrol the paremeter of the ZoneHome if it exists.
+    ---@type IsoPlayer
+    local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
+    -- Cows: Have the guard patrol the perimeter of the ZoneHome if it exists.
     if (npcSurvivor.isHoldingInPlace ~= true) then
         --
+        local zoneType = "ZoneHome";
+        local homeZone = PZNS_UtilsZones.PZNS_GetGroupZoneBoundary(npcSurvivor.groupID, zoneType);
+        local playerSquare = npcIsoPlayer:getSquare();
+        --
+        if (npcSurvivor.jobSquare ~= nil) then
+            -- Cows: let the guard NPC resume its walking patrol along the zone perimeter.
+            npcSurvivor.actionTicks = npcSurvivor.actionTicks + 1;
+            if (npcSurvivor.actionTicks >= 30) then
+                npcIsoPlayer:NPCSetAiming(false);
+                npcIsoPlayer:NPCSetAttack(false);
+                local squareX = npcSurvivor.jobSquare:getX();
+                local squareY = npcSurvivor.jobSquare:getY();
+                local squareZ = npcSurvivor.jobSquare:getZ();
+                -- PZNS_NPCSpeak(npcSurvivor,
+                --     "Moving to " ..
+                --     tostring(squareX) .. ", " ..
+                --     tostring(squareY) .. ", " ..
+                --     tostring(squareZ),
+                --     "InfoOnly"
+                -- );
+                PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor); -- Cows: Clear the actions queue and start moving.
+                PZNS_WalkToSquareXYZ(npcSurvivor, squareX, squareY, squareZ);
+                npcSurvivor.actionTicks = 0;
+            end
+            local distanceFromTarget = PZNS_WorldUtils.PZNS_GetDistanceBetweenTwoObjects(
+                playerSquare,
+                npcSurvivor.jobSquare
+            );
+
+            if (distanceFromTarget <= 0.25) then
+                npcSurvivor.jobSquare = nil;
+                return;
+            end
+        else
+            -- Cows: Else assume the guard has no job square.
+            if (homeZone) then
+                local guardSquare_1 = getCell():getGridSquare(
+                    homeZone[1],
+                    homeZone[3],
+                    homeZone[5] -- Z
+                );
+                local guardSquare_2 = getCell():getGridSquare(
+                    homeZone[2],
+                    homeZone[3],
+                    homeZone[5] -- Z
+                );
+                local guardSquare_3 = getCell():getGridSquare(
+                    homeZone[2],
+                    homeZone[4],
+                    homeZone[5]
+                );
+                local guardSquare_4 = getCell():getGridSquare(
+                    homeZone[1],
+                    homeZone[4],
+                    homeZone[5] -- Z
+                );
+
+                local distanceFromSquare1 = PZNS_WorldUtils.PZNS_GetDistanceBetweenTwoObjects(
+                    playerSquare, guardSquare_1
+                );
+                local distanceFromSquare2 = PZNS_WorldUtils.PZNS_GetDistanceBetweenTwoObjects(
+                    playerSquare, guardSquare_2
+                );
+                local distanceFromSquare3 = PZNS_WorldUtils.PZNS_GetDistanceBetweenTwoObjects(
+                    playerSquare, guardSquare_3
+                );
+
+                if (distanceFromSquare1 <= 1) then
+                    npcSurvivor.jobSquare = guardSquare_2;
+                elseif (distanceFromSquare2 <= 1) then
+                    npcSurvivor.jobSquare = guardSquare_3;
+                elseif (distanceFromSquare3 <= 1) then
+                    npcSurvivor.jobSquare = guardSquare_4;
+                else
+                    npcSurvivor.jobSquare = guardSquare_1;
+                end
+            end
+        end
+    else
+        -- Cows: Else assume the npcSurvivor is holding in place.
+        if (npcSurvivor.jobSquare) then
+            local squareX, squareY, squareZ = npcSurvivor.jobSquare:getX(), npcSurvivor.jobSquare:getY(),
+                npcSurvivor.jobSquare:getZ();
+            PZNS_RunToSquareXYZ(npcSurvivor, squareX, squareY, squareZ);
+        end
     end
-    -- Cows: Else have the guard simply hold position where ever it is.
 end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobsCompanion.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobsCompanion.lua
@@ -141,12 +141,12 @@ function PZNS_JobCompanion(npcSurvivor, targetID)
             -- Cows: Check if target is NOT in a car and exit the car if self is in one.
         elseif (isTargetInCar == nil and isSelfInCar ~= nil) then
             PZNS_ExitVehicle(npcSurvivor);
-        else     -- Cows: Else assume both npcSurvivor and target are on foot.
+        else -- Cows: Else assume both npcSurvivor and target are on foot.
             -- Cows: Companion is currently being forced to move, presumably to keep up with the target.
             if (npcSurvivor.isForcedMoving == true) then
                 npcSurvivor.idleTicks = 0;
                 jobCompanion_Movement(npcSurvivor, targetIsoPlayer);
-                return;     -- Cows: Stop processing and start moving to target.
+                return; -- Cows: Stop processing and start moving to target.
             end
 
             local canSeeTarget = npcIsoPlayer:CanSee(targetIsoPlayer);
@@ -154,11 +154,11 @@ function PZNS_JobCompanion(npcSurvivor, targetID)
             if (isCompanionInFollowRange(npcIsoPlayer, targetIsoPlayer) == false or canSeeTarget == false) then
                 npcSurvivor.idleTicks = 0;
                 jobCompanion_Movement(npcSurvivor, targetIsoPlayer);
-                return;     -- Cows: Stop processing and start moving to target.
+                return; -- Cows: Stop processing and start moving to target.
                 -- Cows: Else Check if the NPC is busy in combat related stuff.
             elseif (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
                 npcSurvivor.idleTicks = 0;
-                return;     -- Cows Stop Processing and let the NPC finish its actions.
+                return; -- Cows Stop Processing and let the NPC finish its actions.
             end
             --Cows: Check if companion has idled for too long and take action.
             if (npcSurvivor.idleTicks >= CompanionIdleTicks) then
@@ -175,7 +175,13 @@ function PZNS_JobCompanion(npcSurvivor, targetID)
         -- Cows: else assume the npcSurvivor is holding in place.
         if (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
             npcSurvivor.idleTicks = 0;
-            return;     -- Cows Stop Processing and let the NPC finish its actions.
+            return; -- Cows Stop Processing and let the NPC finish its actions.
+        end
+        --
+        if (npcSurvivor.jobSquare) then
+            local squareX, squareY, squareZ = npcSurvivor.jobSquare:getX(), npcSurvivor.jobSquare:getY(),
+                npcSurvivor.jobSquare:getZ();
+            PZNS_RunToSquareXYZ(npcSurvivor, squareX, squareY, squareZ);
         end
     end
 end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_ManageJobs.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_ManageJobs.lua
@@ -38,10 +38,16 @@ function PZNS_UpdateNPCJobRoutine(npcSurvivor)
     -- Cows: Check if the NPC's job is currently "Remove" or "Remove Grom Group".
     if (npcSurvivor.jobName == "Remove" or npcSurvivor.jobName == "Remove From Group") then
         -- WIP - Cows: Being removed from the group which should make the NPC angry.
-        if (PZNS_UtilsNPCs.PZNS_IsNPCSpeechTableValid(npcSurvivor.speechTable.PZNS_JobSpeechRemoveFromGroup) == true) then
-            PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
-                npcSurvivor, npcSurvivor.speechTable.PZNS_JobSpeechRemoveFromGroup, "Neutral"
-            );
+        if (npcSurvivor.speechTable ~= nil) then
+            if (npcSurvivor.speechTable.PZNS_JobSpeechRemoveFromGroup ~= nil) then
+                PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                    npcSurvivor, npcSurvivor.speechTable.PZNS_JobSpeechRemoveFromGroup, "Neutral"
+                );
+            else
+                PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                    npcSurvivor, PZNS_PresetsSpeeches.PZNS_JobSpeechRemoveFromGroup, "Neutral"
+                );
+            end
         else
             PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
                 npcSurvivor, PZNS_PresetsSpeeches.PZNS_JobSpeechRemoveFromGroup, "Neutral"

--- a/PZNS_Framework/media/lua/client/08_mod_contextmenu/PZNS_ContextMenuJobs.lua
+++ b/PZNS_Framework/media/lua/client/08_mod_contextmenu/PZNS_ContextMenuJobs.lua
@@ -1,5 +1,6 @@
 local PZNS_UtilsDataNPCs = require("02_mod_utils/PZNS_UtilsDataNPCs");
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
+local PZNS_PresetsSpeeches = require("03_mod_core/PZNS_PresetsSpeeches");
 local PZNS_NPCGroupsManager = require("04_data_management/PZNS_NPCGroupsManager");
 
 ---comment
@@ -19,8 +20,25 @@ function PZNS_CreateJobNPCsMenu(parentContextMenu, mpPlayerID, groupID, jobName)
         local npcSurvivor = activeNPCs[survivorID];
         -- Cows: conditionally set the callback function for the context menu option.
         local callbackFunction = function()
+            npcSurvivor.jobSquare = nil;
             if (jobName == "Companion") then
                 PZNS_JobCompanion(npcSurvivor, followTargetID);
+            end
+            --
+            if (npcSurvivor.speechTable ~= nil) then
+                if (npcSurvivor.speechTable.PZNS_OrderConfirmed ~= nil) then
+                    PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                        npcSurvivor, npcSurvivor.speechTable.PZNS_OrderConfirmed, "Friendly"
+                    );
+                else
+                    PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                        npcSurvivor, PZNS_PresetsSpeeches.PZNS_OrderConfirmed, "Friendly"
+                    );
+                end
+            else
+                PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                    npcSurvivor, PZNS_PresetsSpeeches.PZNS_OrderConfirmed, "Friendly"
+                );
             end
             PZNS_UtilsNPCs.PZNS_SetNPCJob(npcSurvivor, jobName);
             parentContextMenu:setVisible(false);

--- a/PZNS_Framework/media/lua/client/08_mod_contextmenu/PZNS_ContextMenuOrders.lua
+++ b/PZNS_Framework/media/lua/client/08_mod_contextmenu/PZNS_ContextMenuOrders.lua
@@ -40,6 +40,7 @@ function PZNS_CreateGroupNPCsSubMenu(parentContextMenu, mpPlayerID, groupID, ord
         local npcSurvivor = activeNPCs[survivorID];
         -- Cows: Conditionally set the callback function for the context menu option.
         local callbackFunction = function()
+            npcSurvivor.jobSquare = nil;
             -- Cows: Clear the existing queued actions for the npcSurvivor when an Order is issued.
             PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
             local playerSurvivor = getSpecificPlayer(mpPlayerID);
@@ -50,6 +51,10 @@ function PZNS_CreateGroupNPCsSubMenu(parentContextMenu, mpPlayerID, groupID, ord
                     if (npcSurvivor.speechTable.PZNS_OrderSpeechFollow) then
                         PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
                             npcSurvivor, npcSurvivor.speechTable.PZNS_OrderSpeechFollow, "Friendly"
+                        );
+                    else
+                        PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                            npcSurvivor, PZNS_PresetsSpeeches.PZNS_OrderSpeechFollow, "Friendly"
                         );
                     end
                 else
@@ -64,6 +69,10 @@ function PZNS_CreateGroupNPCsSubMenu(parentContextMenu, mpPlayerID, groupID, ord
                         PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
                             npcSurvivor, npcSurvivor.speechTable.PZNS_OrderSpeechHoldPosition, "Friendly"
                         );
+                    else
+                        PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                            npcSurvivor, PZNS_PresetsSpeeches.PZNS_OrderSpeechHoldPosition, "Friendly"
+                        );
                     end
                 else
                     PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
@@ -76,6 +85,10 @@ function PZNS_CreateGroupNPCsSubMenu(parentContextMenu, mpPlayerID, groupID, ord
                     if (npcSurvivor.speechTable.PZNS_OrderConfirmed) then
                         PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
                             npcSurvivor, npcSurvivor.speechTable.PZNS_OrderConfirmed, "Friendly"
+                        );
+                    else
+                        PZNS_UtilsNPCs.PZNS_UseNPCSpeechTable(
+                            npcSurvivor, PZNS_PresetsSpeeches.PZNS_OrderConfirmed, "Friendly"
                         );
                     end
                 else


### PR DESCRIPTION
- Updated conditional speech table usage when NPC is removed from group.
- Updated conditional speech table usage when a job is assigned to NPC.
- Updated conditional speech when Order is issued through the context menu.
- Companions will move towards the square to hold their position.
- Guard Job will now patrol the 4 corners of the group HomeZone.
- Order Follow now updates the jobSquare.
- Order Hold Position now updates the jobSquare.
