### PR TITLE
Job: Wander In Building Update

### DIFF
--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
@@ -515,12 +515,13 @@ end
 
 --- WIP - Cows: Check and update the npcSurvivor isStuckTicks (depending on the npcSurvivor currentAction?)
 ---@param npcSurvivor any
-function PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor)
+---@param tickInterval number
+function PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor, tickInterval)
     if (npcSurvivor.isStuckTicks == nil) then
         npcSurvivor.isStuckTicks = 0;
     end
     -- Cows: 50 Ticks per action on average... also need ticks for animations.
-    if (npcSurvivor.isStuckTicks >= 150) then
+    if (npcSurvivor.isStuckTicks > tickInterval) then
         PZNS_NPCSpeak(npcSurvivor, "I was stuck...", "InfoOnly");
         PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
         npcSurvivor.currentAction = "";
@@ -528,7 +529,7 @@ function PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor)
     else
         npcSurvivor.isStuckTicks = npcSurvivor.isStuckTicks + 1;
     end
-    PZNS_NPCSpeak(npcSurvivor, "isStuckTicks: " .. tostring(npcSurvivor.isStuckTicks), "InfoOnly");
+    -- PZNS_NPCSpeak(npcSurvivor, "isStuckTicks: " .. tostring(npcSurvivor.isStuckTicks), "InfoOnly");
 end
 
 --- Cows: This is to streamline the multiple npcIsoPlayerObject checks...

--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_WorldUtils.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_WorldUtils.lua
@@ -151,4 +151,66 @@ function PZNS_WorldUtils.PZNS_ClearZombiesFromSquare(targetSquare, squareRadius)
     end
 end
 
+--- Cows: Gets a list of buildings in the cell.
+function PZNS_WorldUtils.PZNS_GetCellBuildingsList()
+    local buildingsList = getCell():getBuildingList();
+    return buildingsList;
+end
+
+--- Cows: 
+---@param buildingsList ArrayList
+---@return any returns a random building from the buildingsList
+function PZNS_WorldUtils.PZNS_GetRandomBuildingFromCell(buildingsList)
+    local building = buildingsList[ZombRand(0, buildingsList:size() - 1)];
+    return building;
+end
+
+---
+---@param building IsoBuilding
+---@return any returns a list of rooms in the specified building.
+function PZNS_WorldUtils.PZNS_GetBuildingRooms(building)
+    local bdef = building:getDef();
+    local rooms = bdef:getRooms();
+    return rooms;
+end
+
+---
+---@param building IsoBuilding
+---@return any returns a random rooms in the specified building.
+function PZNS_WorldUtils.PZNS_GetBuildingRandomRoom(building)
+    local randomRoom = building:getRandomRoom();
+    return randomRoom;
+end
+
+---
+---@param room IsoRoom
+---@return any returns a list of squares in the specified room.
+function PZNS_WorldUtils.PZNS_GetBuildingRoomSquares(room)
+    local squares = room:getSquares();
+    return squares;
+end
+
+---
+---@param room IsoRoom
+---@return any returns a random free square in the specified room.
+function PZNS_WorldUtils.PZNS_GetBuildingRoomRandomFreeSquare(room)
+    local squares = room:getRandomFreeSquare();
+    return squares;
+end
+
+--- Cows: Based on 'GetRandomBuildingSquare()' from SuperSurvivorContextUtilities.lua
+---@param building IsoBuilding
+---@return any returns a random square inside of the building
+function PZNS_WorldUtils.PZNS_GetBuildingRandomSquare(building)
+    local bdef = building:getDef();
+    local x = ZombRand(bdef:getX(), (bdef:getX() + bdef:getW()));
+    local y = ZombRand(bdef:getY(), (bdef:getY() + bdef:getH()));
+    local sq = getCell():getGridSquare(x, y, 0);
+
+    if (sq) then
+        return sq;
+    end
+    return nil;
+end
+
 return PZNS_WorldUtils;

--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_WorldUtils.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_WorldUtils.lua
@@ -176,7 +176,7 @@ end
 
 ---
 ---@param building IsoBuilding
----@return any returns a random rooms in the specified building.
+---@return any returns a random room in the specified building.
 function PZNS_WorldUtils.PZNS_GetBuildingRandomRoom(building)
     local randomRoom = building:getRandomRoom();
     return randomRoom;

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_RunTo.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_RunTo.lua
@@ -125,7 +125,7 @@ function PZNS_RunToTimedAction:new(character, location, additionalTest, addition
     return o;
 end
 
----comment
+--- Cows: Have the specified NPC move to the square specified by xyz coordinates.
 ---@param npcSurvivor any
 ---@param squareX any
 ---@param squareY any

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WalkTo.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WalkTo.lua
@@ -1,6 +1,6 @@
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 
----comment
+--- Cows: Have the specified NPC move to the square specified by xyz coordinates.
 ---@param npcSurvivor any
 ---@param squareX any
 ---@param squareY any

--- a/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_MoveToDropItem.lua
+++ b/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_MoveToDropItem.lua
@@ -15,7 +15,7 @@ function PZNS_MoveToDropItem(npcSurvivor, square, itemToDrop)
     local squareX, squareY, squareZ = square:getX(), square:getY(), square:getZ();
     -- Cows: Make sure the NPC drop off is INSIDE the square, otherwise it will pickup the item right outside the destination square.
     if (distanceFromDropoff <= 0.75) then
-        PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor);
+        PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor, 150);
         --
         if (npcSurvivor.currentAction ~= "DropItem") then
             PZNS_DropItem(npcSurvivor, itemToDrop);

--- a/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_MoveToGrabCorpse.lua
+++ b/PZNS_Framework/media/lua/client/06_npc_orders/PZNS_MoveToGrabCorpse.lua
@@ -15,7 +15,7 @@ function PZNS_MoveToGrabCorpse(npcSurvivor, square, deadBody)
     local squareX, squareY, squareZ = square:getX(), square:getY(), square:getZ();
     --
     if (distanceFromPickup <= 1) then
-        PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor);
+        PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor, 150);
         --
         if (npcSurvivor.currentAction ~= "GrabCorpse") then
             PZNS_GrabCorpse(npcSurvivor, deadBody);

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
@@ -43,7 +43,7 @@ function PZNS_GeneralAI.PZNS_IsReloadNeeded(npcSurvivor)
                             and lastAction.Type ~= "ISInsertMagazine"
                             and lastAction.Type ~= "ISRackFirearm"
                             and lastAction.Type ~= "ISReloadWeaponAction"
-                            and lastAction.Type ~= "ISWalkToTimedAction"  -- Cows: Well, reload while walking IS possible...
+                            and lastAction.Type ~= "ISWalkToTimedAction" -- Cows: Well, reload while walking IS possible...
                         ) then
                         PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
                     end
@@ -73,7 +73,7 @@ function PZNS_GeneralAI.PZNS_CanSeeAimTarget(npcSurvivor)
                 npcSurvivor.aimTarget
             );
             if (distanceFromTarget <= 30) then
-                local canSeeTarget = npcIsoPlayer:CanSee(npcSurvivor.aimTarget);     -- Cows: "vision cone" isn't a thing for NPCs... they can "see" the world objects without facing them.
+                local canSeeTarget = npcIsoPlayer:CanSee(npcSurvivor.aimTarget); -- Cows: "vision cone" isn't a thing for NPCs... they can "see" the world objects without facing them.
                 return canSeeTarget;
             end
         end
@@ -90,13 +90,11 @@ function PZNS_GeneralAI.PZNS_NPCAimAttack(npcSurvivor)
     end
     ---@type IsoPlayer
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
-    if (npcIsoPlayer) then
-        -- Cows: Can only aim and/or attack if npcSurvivor is Alive.
-        if (npcIsoPlayer:isAlive() == true) then
-            if (npcSurvivor.aimTarget ~= nil) then
-                PZNS_WeaponAiming(npcSurvivor); -- Cows: Aim before attacking
-                PZNS_WeaponAttack(npcSurvivor); -- Cows: Permission to attack is handled in the function.
-            end
+    -- Cows: Can only aim and/or attack if npcSurvivor is Alive.
+    if (npcIsoPlayer:isAlive() == true) then
+        if (npcSurvivor.aimTarget ~= nil) then
+            PZNS_WeaponAiming(npcSurvivor); -- Cows: Aim before attacking
+            PZNS_WeaponAttack(npcSurvivor); -- Cows: Permission to attack is handled in the function.
         end
     end
 end
@@ -156,6 +154,24 @@ function PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor)
         return true; -- Cows: Stop processing and start attacking.
     end
 
+    return false;
+end
+
+--- WIP - Cows: This is a placeholder... Added to allow NPCs to evaluate potential obstacles in their paths...
+---@param npcSurvivor any
+function PZNS_GeneralAI.PZNS_IsPathBlocked(npcSurvivor)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return true;
+    end
+    ---@type IsoPlayer
+    local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
+    -- Cows: Check if the NPC is facing a door
+    if (npcIsoPlayer:isFacingObject(IsoDoor, 1) == true) then
+        -- Cows: Check if the door is locked (perhaps also need to check for a key... then follow up with more complicated actions such as unlocking and destroying...)
+        if (IsoDoor:isLocked() == true) then
+            return true;
+        end
+    end
     return false;
 end
 

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInBuilding.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInBuilding.lua
@@ -1,0 +1,14 @@
+local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
+local PZNS_GeneralAI = require("07_npc_ai/PZNS_GeneralAI");
+
+---comment
+---@param npcSurvivor any
+function PZNS_JobWanderInBuilding(npcSurvivor)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return;
+    end
+    if (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
+        return; -- Cows Stop Processing and let the NPC finish its actions.
+    end
+    --- Cows: Now we can assume the NPC is valid and not busy in combat below this line ---
+end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInBuilding.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInBuilding.lua
@@ -1,7 +1,12 @@
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
+local PZNS_WorldUtils = require("02_mod_utils/PZNS_WorldUtils");
 local PZNS_GeneralAI = require("07_npc_ai/PZNS_GeneralAI");
 
----comment
+--[[
+    - WIP - Cows: "Wandering" can be unpredictable and without destination nor end goal... so my intent is to categorize the "wandering" into limited or specified areas to limit potential issues.
+--]]
+
+--- Cows: This "Job" has the NPC move around inside the current building it is in.
 ---@param npcSurvivor any
 function PZNS_JobWanderInBuilding(npcSurvivor)
     if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
@@ -11,4 +16,100 @@ function PZNS_JobWanderInBuilding(npcSurvivor)
         return; -- Cows Stop Processing and let the NPC finish its actions.
     end
     --- Cows: Now we can assume the NPC is valid and not busy in combat below this line ---
+    ---@type IsoPlayer
+    local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
+    local npcPlayerSquare = npcIsoPlayer:getSquare();
+
+    -- Cows: Check if npcSurvivor is not holding in place
+    if (npcSurvivor.isHoldingInPlace ~= true) then
+        -- Cows: Check if the npcSurvivor has a destination with jobSquare
+        if (npcSurvivor.jobSquare == nil) then
+            local targetBuilding = npcPlayerSquare:getBuilding();
+            -- Cows: Check if the target building is nil, if true, look for another building in the cell.
+            if (targetBuilding == nil) then
+                -- Cows: get the list of buildings in the cell
+                local buildingsInCell = PZNS_WorldUtils.PZNS_GetCellBuildingsList();
+                if (buildingsInCell) then
+                    targetBuilding = PZNS_WorldUtils.PZNS_GetRandomBuildingFromCell(buildingsInCell);
+                else
+                    -- Cows: Else there is no building in the cell to go into... what should the NPC do in this case?
+                    PZNS_NPCSpeak(npcSurvivor, "I have no buildings in the cell...", "InfoOnly");
+                    return;
+                end
+            end
+            -- Cows: Check if the target building is nil again, if true, stop
+            if (targetBuilding == nil) then
+                -- Cows: At this point, there is no building to wander in... what should the NPC do in this case?
+                PZNS_NPCSpeak(npcSurvivor, "I have no building to wander in...", "InfoOnly");
+                return;
+            end
+            -- Cows: Now we can finally assume there is a target building for the NPC to get into, hopefully with a room and square.
+            local randomRoom = PZNS_WorldUtils.PZNS_GetBuildingRandomRoom(targetBuilding);
+            if (randomRoom) then
+                local randomRoomSquare = PZNS_WorldUtils.PZNS_GetBuildingRoomRandomFreeSquare(randomRoom);
+                if (randomRoomSquare) then
+                    npcSurvivor.idleTicks = 0;
+                    npcSurvivor.isStuckTicks = 0;
+                    npcSurvivor.jobSquare = randomRoomSquare;
+                    local squareX = npcSurvivor.jobSquare:getX();
+                    local squareY = npcSurvivor.jobSquare:getY();
+                    local squareZ = npcSurvivor.jobSquare:getZ();
+                    PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor); -- Cows: Clear the actions queue and start moving.
+                    PZNS_WalkToSquareXYZ(npcSurvivor, squareX, squareY, squareZ);
+                else
+                    -- Cows: At this point, there is no square to move to... what should the NPC do in this case?
+                    PZNS_NPCSpeak(npcSurvivor, "I have no square to move to...", "InfoOnly");
+                end
+            else
+                -- Cows: At this point, there is no room to move to... what should the NPC do in this case?
+                PZNS_NPCSpeak(npcSurvivor, "I have no room to move to...", "InfoOnly");
+            end
+        else
+            -- Cows: use idleTicks instead of action ticks, because the NPC is wandering around. Also because other actions may use actionTicks.
+            npcSurvivor.idleTicks = npcSurvivor.idleTicks + 1;
+            -- Cows: Else assume the NPC is moving inside the building it is in.
+            local distanceFromTarget = PZNS_WorldUtils.PZNS_GetDistanceBetweenTwoObjects(
+                npcIsoPlayer, npcSurvivor.jobSquare
+            );
+            -- Cows: Check if the NPC is near its destination...
+            if (distanceFromTarget < 1) then
+                -- Cows: Allow the NPC to idle for a moment before restarting its routine.
+                if (npcSurvivor.idleTicks >= 600) then
+                    npcSurvivor.jobSquare = nil;
+                end
+                return;-- Cows: Stop processing, the NPC is already at it's destination.
+            else
+                -- Cows: Else Update the movement calculation every 300 ticks to reduce action queuing and resume the movement.
+                local moveTickInterval = 300;
+                if (npcSurvivor.idleTicks >= moveTickInterval) then
+                    -- Cows: Check the NPC at regular intervals to see if it is stuck in the same square...
+                    local isStuck = npcIsoPlayer:getLastSquare() == npcPlayerSquare;
+                    if (isStuck == true) then
+                        -- Cows: only need 2 for the stuck interval check, because the moveTickInterval is 300; 2 * 300 = 600 ticks to confirm the NPC is stuck.
+                        PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor, 2);
+                        if (npcSurvivor.isStuckTicks >= 2) then
+                            npcSurvivor.jobSquare = nil;
+                        end
+                    end
+                    --
+                    if (npcSurvivor.jobSquare) then
+                        local squareX = npcSurvivor.jobSquare:getX();
+                        local squareY = npcSurvivor.jobSquare:getY();
+                        local squareZ = npcSurvivor.jobSquare:getZ();
+                        PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor); -- Cows: Clear the actions queue and start moving.
+                        PZNS_WalkToSquareXYZ(npcSurvivor, squareX, squareY, squareZ);
+                    end
+                    npcSurvivor.idleTicks = 0;
+                end
+            end
+        end
+    else
+        -- Cows: Else assume the npcSurvivor is holding in place.
+        if (npcSurvivor.jobSquare) then
+            local squareX = npcSurvivor.jobSquare:getX();
+            local squareY = npcSurvivor.jobSquare:getY();
+            local squareZ = npcSurvivor.jobSquare:getZ();
+            PZNS_WalkToSquareXYZ(npcSurvivor, squareX, squareY, squareZ);
+        end
+    end
 end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInBuilding.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInBuilding.lua
@@ -79,15 +79,16 @@ function PZNS_JobWanderInBuilding(npcSurvivor)
                 end
                 return;-- Cows: Stop processing, the NPC is already at it's destination.
             else
-                -- Cows: Else Update the movement calculation every 300 ticks to reduce action queuing and resume the movement.
-                local moveTickInterval = 300;
+                -- Cows: Else Update the movement calculation every 200 ticks to reduce action queuing and resume the movement.
+                local moveTickInterval = 200;
                 if (npcSurvivor.idleTicks >= moveTickInterval) then
                     -- Cows: Check the NPC at regular intervals to see if it is stuck in the same square...
                     local isStuck = npcIsoPlayer:getLastSquare() == npcPlayerSquare;
                     if (isStuck == true) then
-                        -- Cows: only need 2 for the stuck interval check, because the moveTickInterval is 300; 2 * 300 = 600 ticks to confirm the NPC is stuck.
-                        PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor, 2);
-                        if (npcSurvivor.isStuckTicks >= 2) then
+                        -- Cows: Only need 1 for the stuck interval check, isStuckTicks starts at 0 and is inside the moveTickInterval.
+                        -- Cows: This means the stuck check is done twice at 0 and 1, at 200 and 400 ticks respectively.
+                        PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor, 1);
+                        if (npcSurvivor.isStuckTicks >= 1) then
                             npcSurvivor.jobSquare = nil;
                         end
                     end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInCell.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInCell.lua
@@ -1,6 +1,10 @@
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 local PZNS_GeneralAI = require("07_npc_ai/PZNS_GeneralAI");
 
+--[[
+    - WIP - Cows: "Wandering" can be unpredictable and without destination nor end goal... so my intent is to categorize the "wandering" into limited or specified areas to limit potential issues. 
+--]]
+
 ---comment
 ---@param npcSurvivor any
 function PZNS_JobWanderInCell(npcSurvivor)

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInCell.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInCell.lua
@@ -1,0 +1,14 @@
+local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
+local PZNS_GeneralAI = require("07_npc_ai/PZNS_GeneralAI");
+
+---comment
+---@param npcSurvivor any
+function PZNS_JobWanderInCell(npcSurvivor)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return;
+    end
+    if (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
+        return; -- Cows Stop Processing and let the NPC finish its actions.
+    end
+    --- Cows: Now we can assume the NPC is valid and not busy in combat below this line ---
+end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInZone.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInZone.lua
@@ -1,0 +1,14 @@
+local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
+local PZNS_GeneralAI = require("07_npc_ai/PZNS_GeneralAI");
+
+---comment
+---@param npcSurvivor any
+function PZNS_JobWanderInZone(npcSurvivor)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return;
+    end
+    if (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
+        return; -- Cows Stop Processing and let the NPC finish its actions.
+    end
+    --- Cows: Now we can assume the NPC is valid and not busy in combat below this line ---
+end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInZone.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInZone.lua
@@ -1,6 +1,10 @@
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 local PZNS_GeneralAI = require("07_npc_ai/PZNS_GeneralAI");
 
+--[[
+    - WIP - Cows: "Wandering" can be unpredictable and without destination nor end goal... so my intent is to categorize the "wandering" into limited or specified areas to limit potential issues. 
+--]]
+
 ---comment
 ---@param npcSurvivor any
 function PZNS_JobWanderInZone(npcSurvivor)

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_ManageJobs.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_ManageJobs.lua
@@ -18,7 +18,8 @@ PZNS_JobsText = {
     -- Engineer = getText("ContextMenu_PZNS_Engineer"),, -- WIP - Cows: Commented out until implementation is ready.
     Guard = getText("ContextMenu_PZNS_Guard"),
     Undertaker = getText("ContextMenu_PZNS_Undertaker"),
-    Remove = getText("ContextMenu_PZNS_Remove_From_Group")
+    Remove = getText("ContextMenu_PZNS_Remove_From_Group"),
+    WanderInBuilding = "Wander In Building"
 };
 -- WIP - Cows: Need to rethink how Global variables are used...
 PZNS_Jobs = {
@@ -29,6 +30,7 @@ PZNS_Jobs = {
     Undertaker = PZNS_JobUndertaker,
     Remove = doNothing
 };
+
 --- Cows: Helper function for PZNS_UpdateAllJobsRoutines(), can also be used to update an npc's routine when their job is changed.
 ---@param npcSurvivor any
 function PZNS_UpdateNPCJobRoutine(npcSurvivor)
@@ -58,14 +60,27 @@ function PZNS_UpdateNPCJobRoutine(npcSurvivor)
         PZNS_UtilsNPCs.PZNS_SetNPCJob(npcSurvivor, "Guard"); -- WIP - Cows: Currently there is no NPC "wandering" AI nor job... so this is a placeholder
         return;                                              -- Cows: Stop Processing, the npc is no longer in the group.
     end
+    if (npcSurvivor.jobName == nil) then
+         return;
+    end
+    if (npcSurvivor.jobName == "") then
+        return;
+    end
     -- Cows: Only update living npcSurvivor routine.
     if (npcSurvivor.isAlive == true) then
+        -- Cows: This job name mapping only works if the job name is ONE WORD.
         if (PZNS_Jobs[npcSurvivor.jobName] ~= nil) then
             --
             if (npcSurvivor.jobName == "Companion") then
                 PZNS_Jobs[npcSurvivor.jobName](npcSurvivor, npcSurvivor.followTargetID);
             else
                 PZNS_Jobs[npcSurvivor.jobName](npcSurvivor);
+            end
+        else
+            if (npcSurvivor.jobName == "Wander In Building") then
+                PZNS_JobWanderInBuilding(npcSurvivor);
+            else
+                PZNS_NPCSpeak(npcSurvivor, "I am not doing a known job", "InfoOnly");
             end
         end
     end
@@ -79,8 +94,8 @@ function PZNS_UpdateAllJobsRoutines()
     -- Cows: Go through all the active NPCs and update their job routines
     for survivorID, v1 in pairs(activeNPCs) do
         local npcSurvivor = activeNPCs[survivorID];
-        -- Cows: Only update living npcSurvivors
-        if (npcSurvivor.isAlive == true) then
+        -- Cows: Only update spawned and living npcSurvivors
+        if (npcSurvivor.isSpawned  == true and npcSurvivor.isAlive == true) then
             PZNS_UpdateNPCJobRoutine(npcSurvivor);
         end
     end


### PR DESCRIPTION
PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
- PZNS_StuckNPCCheck() - Added a tickInterval input parameter to allow flexibility in determining when an NPC is stuck.

PZNS_Framework/media/lua/client/02_mod_utils/PZNS_WorldUtils.lua
- Added a bunch of building and room related code, will need more testing and validation on which of those APIs actually work...

PZNS_Framework/media/lua/client/05_npc_actions/PZNS_RunTo.lua
- Added code comment

PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WalkTo.lua
- Added code comment

PZNS_Framework/media/lua/client/06_npc_orders/PZNS_MoveToDropItem.lua
- Added 150 to tickInterval for PZNS_StuckNPCCheck()

PZNS_Framework/media/lua/client/06_npc_orders/PZNS_MoveToGrabCorpse.lua
- Added 150 to tickInterval for PZNS_StuckNPCCheck()

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
- Updated code formatting
- Added a placeholder function for pathblock check.

PZNS_JobWanderInBuilding.lua
- A new job for NPCs to wander inside a building.
- Needs more testing...

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInCell.lua
- Placeholder, will follow-up later.

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInZone.lua
- Placeholder, will follow-up later.

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_ManageJobs.lua
- Added conditional handler for job "Wander in Building".
- Added conditional handler for unrecognized job(s).

