### PR TITLE
Jobs Routines Update

### DIFF
--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
@@ -9,6 +9,36 @@ local PZNS_WorldUtils = require("02_mod_utils/PZNS_WorldUtils");
 
 local PZNS_GeneralAI = {};
 
+---Cows: A function to check if the NPC is armed.
+---@param npcSurvivor any
+---@return boolean
+function PZNS_GeneralAI.PZNS_IsNPCArmed(npcSurvivor)
+    if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
+        return false;
+    end
+    local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
+    ---@type HandWeapon
+    local npcHandItem = npcIsoPlayer:getPrimaryHandItem();
+    -- Cows: No item in hand equals NPC is unarmed.
+    if (npcHandItem == nil) then
+        return false;
+    end
+    -- Cows: Check if theh and item is a weapon.
+    if (npcHandItem:IsWeapon() == true) then
+        if (npcHandItem:isRanged() == true) then
+            -- Cows: Check if the gun has ammo
+            if (npcHandItem:getCurrentAmmoCount() > 0) then
+                return true;
+            end
+        else
+            -- Cows: Else assume the weapon is melee and the NPC is armed.
+            return true;
+        end
+    end
+    -- Cows: Default to false.
+    return false;
+end
+
 ---comment
 ---@param npcSurvivor any
 ---@return boolean

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
@@ -100,11 +100,6 @@ function PZNS_JobGuard(npcSurvivor)
             end
         end
     else
-        -- Cows: Else assume the npcSurvivor is holding in place.
-        if (npcSurvivor.jobSquare) then
-            local squareX, squareY, squareZ = npcSurvivor.jobSquare:getX(), npcSurvivor.jobSquare:getY(),
-                npcSurvivor.jobSquare:getZ();
-            PZNS_RunToSquareXYZ(npcSurvivor, squareX, squareY, squareZ);
-        end
+        PZNS_GeneralAI.PZNS_WalkToJobSquare(npcSurvivor);
     end
 end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
@@ -9,8 +9,16 @@ function PZNS_JobGuard(npcSurvivor)
     if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
-    if (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
-        return; -- Cows Stop Processing and let the NPC finish its actions.
+    local isNPCArmed = PZNS_GeneralAI.PZNS_IsNPCArmed(npcSurvivor);
+    -- Cows: Only engage in combat if NPC has permission to attack and NPC is also armed.
+    if (npcSurvivor.canAttack == true and isNPCArmed == true) then
+        if (PZNS_GeneralAI.PZNS_IsNPCBusyCombat(npcSurvivor) == true) then
+            return; -- Cows Stop Processing and let the NPC finish its actions.
+        end
+    elseif (isNPCArmed == false) then
+        PZNS_NPCSpeak(npcSurvivor, getText("IGUI_PZNS_Speech_Preset_NeedWeapon_01"), "Negative");
+    elseif (npcSurvivor.canAttack == false) then
+        PZNS_NPCSpeak(npcSurvivor, getText("IGUI_PZNS_Speech_Preset_CannotAttack_01"), "InfoOnly");
     end
     -- Cows: No Group means no zone to guard... for now.
     if (npcSurvivor.groupID == nil) then


### PR DESCRIPTION
PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
- Added an "PZNS_IsNPCArmed()" function check.

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
- Simplified walk to job square
- Guard job will now speak if they are unarmed or do not have permission to attack

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobUndertaker.lua
- Updated checks and the frequency of checks; should be less CPU intensive than before.
- The issue with ForceUnequipped is still unresolved... 

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobsCompanion.lua
- Revamped the HoldingInPlace update for companion, they should move more responsively than before.