### PR TITLE
Undrawn npc fix

### DIFF
--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_WorldUtils.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_WorldUtils.lua
@@ -41,6 +41,13 @@ end
 ---@param squareY number
 ---@param squareZ number
 function PZNS_WorldUtils.PZNS_IsSquareInPlayerSpawnRange(playerSurvivor, squareX, squareY, squareZ)
+    -- Cows: Only continue to check spawn range if the playerSurvivor not nil and is alive.
+    if (playerSurvivor == nil) then
+        return;
+    end
+    if (playerSurvivor:isAlive() ~= true) then
+        return;
+    end
     local o1x = playerSurvivor:getX();
     local o1y = playerSurvivor:getY();
     local o1z = playerSurvivor:getZ();

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponAttack.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponAttack.lua
@@ -16,8 +16,8 @@ local function calculateNPCDamage(npcIsoPlayer, victim)
     local npcWeapon = npcIsoPlayer:getPrimaryHandItem();
     local actualHitChance = PZNS_CombatUtils.PZNS_CalculateHitChance(npcWeapon, aimingLevel, 0);
     local weaponDamage = npcWeapon:getMaxDamage(); -- Cows: Need to look at redoing weapon damage... otherwise NPC melee weapons will destroy everything at max damage.
-    -- Cows: If the victim not an NPC, activate PVP.
-    if (victim:getIsNPC() == false) then
+    -- Cows: Check if the victim is an IsoPlayer and not an NPC
+    if (instanceof(victim, "IsoPlayer") == true and victim:getIsNPC() == false) then
         if (IsPVPActive == false) then
             PZNS_CombatUtils.PZNS_TogglePvP();
         end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
@@ -177,7 +177,7 @@ function PZNS_GeneralAI.PZNS_CheckForThreats(npcSurvivor)
         -- Check if the player is inside the spotting range
         if (canSeeTarget == true and distanceFromPlayerSurvivor < spottingRange) then
             priorityThreatDistance = distanceFromPlayerSurvivor;
-            priorityThreatObject = "player0";
+            priorityThreatObject = playerSurvivor;
             isThreatExist = true;
         end
     end

--- a/PZNS_Framework/media/lua/client/11_events_spawning/PZNS_Events.lua
+++ b/PZNS_Framework/media/lua/client/11_events_spawning/PZNS_Events.lua
@@ -44,6 +44,8 @@ local function PZNS_Events()
     if (IsNPCsNeedsActive ~= true) then
         Events.EveryHours.Add(PZNS_UtilsNPCs.PZNS_ClearAllNPCsAllNeedsLevel);
     end
+    -- Cows: May need to change this to OnPlayerUpdate to address https://github.com/shadowhunter100/PZNS/issues/34...
+    -- Cows: Maybe not, since the NPCs will be unloaded much more aggressively/sooner at 45 squares, will confirm after more testing.
     Events.EveryOneMinute.Add(PZNS_WorldUtils.PZNS_SpawnNPCIfSquareIsLoaded);
     Events.OnRenderTick.Add(PZNS_UpdateAllJobsRoutines);
     Events.OnRenderTick.Add(PZNS_RenderNPCsText);


### PR DESCRIPTION
PZNS_Framework/media/lua/client/02_mod_utils/PZNS_WorldUtils.lua
- PZNS_IsSquareInPlayerSpawnRange() - Updated to check if the player is alive and not nil; otherwise if/when player dies it throws an error.
- local function spawnNPCIsoPlayer() 
  - Updated to check if NPC square is inside the spawn range (<= 45 squares of the player). 
  - This is to address a reported issue with invisible NPCs https://github.com/shadowhunter100/PZNS/issues/36
  - The hypothesis is that the NPC and/or square in question is in "memory" but for whatever reason, fail to draw the npc object on the square.
  - So by aggressively clearing out the NPCs whenever it is beyond 45 squares and only spawning in at <= 45 squares, the square and whatever object(s) on it _should_ render as expected.
- PlayerSayIsNPCSquareOnScreen() - Added to test and check whether or not a specific NPC square is on screen.

PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponAttack.lua
- Hotfix to ensure PVP is only activated when the player is hit.

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
- Hotfix to ensure the player is targetable by NPCs.

PZNS_Framework/media/lua/client/11_events_spawning/PZNS_Events.lua
- Added comments to address reported issue https://github.com/shadowhunter100/PZNS/issues/34