### PR TITLE
Added a function to remove non-Zombie corpses within 30 squares of the player

### DIFF
--- a/PZNS_Framework/media/lua/client/08_mod_contextmenu/PZNS_ContextMenuDebug.lua
+++ b/PZNS_Framework/media/lua/client/08_mod_contextmenu/PZNS_ContextMenuDebug.lua
@@ -197,7 +197,9 @@ local PZNS_DebugWorldText = {
     SpawnJill = getText("ContextMenu_PZNS_ReSpawn_Jill_Tester"),
     SpawnZombie = getText("ContextMenu_PZNS_Spawn_Zombie"),
     SpawnRaider = getText("ContextMenu_PZNS_Spawn_Raider"),
-    SpawnNPCSurvivor = getText("ContextMenu_PZNS_Spawn_Survivor")
+    SpawnNPCSurvivor = getText("ContextMenu_PZNS_Spawn_Survivor"),
+    RemoveDeadBodies = getText("ContextMenu_PZNS_Remove_Dead_Bodies"),
+    
 };
 ---
 local PZNS_DebugWorld = {
@@ -207,7 +209,8 @@ local PZNS_DebugWorld = {
     SpawnJill = respawnJillTester,
     SpawnZombie = spawnZombieAtSquare,
     SpawnRaider = PZNS_NPCsManager.spawnRandomRaiderSurvivorAtSquare,
-    SpawnNPCSurvivor = PZNS_NPCsManager.spawnRandomNPCSurvivorAtSquare
+    SpawnNPCSurvivor = PZNS_NPCsManager.spawnRandomNPCSurvivorAtSquare,
+    RemoveDeadBodies = PZNS_DebuggerUtils.PZNS_RemoveDeadBodies
 };
 
 --- Cows: mpPlayerID is a placeholder, it doesn't do anything and defaults to 0 in a local game.

--- a/PZNS_Framework/media/lua/shared/Translate/CH/ContextMenu_CH.txt
+++ b/PZNS_Framework/media/lua/shared/Translate/CH/ContextMenu_CH.txt
@@ -19,6 +19,7 @@ ContextMenu_CH = {
 		ContextMenu_PZNS_PZNS_Debug_Build = "PZNS 調試建造",
 		ContextMenu_PZNS_Clear_Player_Needs = "滿足玩家生活需求",
 		ContextMenu_PZNS_Clear_All_NPCs_Needs = "滿足全部 NPC 生活需求",
+		ContextMenu_PZNS_Remove_Dead_Bodies = "移除非殭屍屍體",
 		ContextMenu_PZNS_ReSpawn_Chris_Tester = "（重新）生成 Chris Tester",
 		ContextMenu_PZNS_ReSpawn_Jill_Tester = "（重新）生成 Jill Tester",
 		ContextMenu_PZNS_Spawn_Zombie = "生成一個殭屍",

--- a/PZNS_Framework/media/lua/shared/Translate/CN/ContextMenu_CN.txt
+++ b/PZNS_Framework/media/lua/shared/Translate/CN/ContextMenu_CN.txt
@@ -19,6 +19,7 @@ ContextMenu_CN = {
 		ContextMenu_PZNS_PZNS_Debug_Build = "PZNS 调试建造",
 		ContextMenu_PZNS_Clear_Player_Needs = "满足玩家生活需求",
 		ContextMenu_PZNS_Clear_All_NPCs_Needs = "满足全部 NPC 生活需求",
+		ContextMenu_PZNS_Remove_Dead_Bodies = "移除非僵尸尸体",
 		ContextMenu_PZNS_ReSpawn_Chris_Tester = "（重新）生成 Chris Tester",
 		ContextMenu_PZNS_ReSpawn_Jill_Tester = "（重新）生成 Jill Tester",
 		ContextMenu_PZNS_Spawn_Zombie = "生成一个僵尸",

--- a/PZNS_Framework/media/lua/shared/Translate/EN/ContextMenu_EN.txt
+++ b/PZNS_Framework/media/lua/shared/Translate/EN/ContextMenu_EN.txt
@@ -19,6 +19,7 @@ ContextMenu_EN = {
 		ContextMenu_PZNS_PZNS_Debug_Build = "PZNS Debug Build",
 		ContextMenu_PZNS_Clear_Player_Needs = "Clear Player Needs",
 		ContextMenu_PZNS_Clear_All_NPCs_Needs = "Clear All NPC Needs",
+		ContextMenu_PZNS_Remove_Dead_Bodies = "Remove Non-Zombie Dead Bodies",
 		ContextMenu_PZNS_ReSpawn_Chris_Tester = "(Re)Spawn Chris Tester",
 		ContextMenu_PZNS_ReSpawn_Jill_Tester = "(Re)Spawn Jill Tester",
 		ContextMenu_PZNS_Spawn_Zombie = "Spawn a Zombie",


### PR DESCRIPTION
Added a function to remove non-Zombie corpses within 30 squares of the player with translation files.

PZNS_Framework/media/lua/client/02_mod_utils/PZNS_DebuggerUtils.lua
- PZNS_GetAllObjectsInCell() - Added a few more list API calls, all returned nothing.
- PZNS_RemoveDeadBodies() - Added to remove dead non-zombie bodies within 30 squares of the player.

PZNS_Framework/media/lua/client/08_mod_contextmenu/PZNS_ContextMenuDebug.lua
- Added Remove Dead bodies to the Debug World context menu

Added Translation files
- Chinese (Traditional)
- Chinese (Simplified)
- English
  