### PR TITLE
Manage jobs update

### DIFF
--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsDataNPCs.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsDataNPCs.lua
@@ -145,6 +145,7 @@ function PZNS_UtilsDataNPCs.PZNS_SpawnNPCFromModData(npcSurvivor)
         npcSurvivor.textObject:setDefaultFont(UIFont.Small);
         npcSurvivor.textObject:setDefaultColors(255, 255, 255);
         npcSurvivor.textObject:ReadString(npcSurvivor.survivorName);
+        npcSurvivor.isSavedInWorld = false;
         npcSurvivor.isSpawned = true;
     end
     return npcSurvivor;

--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
@@ -378,16 +378,24 @@ function PZNS_UtilsNPCs.PZNS_GetIsNPCSquareLoaded(npcSurvivor)
     if (npcSurvivor == nil) then
         return false;
     end
+    local npcSquare = nil;
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
-    --
+    -- Cows: Use the current IsoPlayer's object position if available
     if (npcIsoPlayer) then
-        local npcSquare = npcIsoPlayer:getSquare();
-        --
-        if (npcSquare ~= nil) then
-            return true;
-        end
+        npcSquare = npcIsoPlayer:getSquare();
+    else
+        -- Cows: Else Use the last known/saved position of the NPC
+        npcSquare = getCell():getGridSquare(
+            npcSurvivor.squareX,
+            npcSurvivor.squareY,
+            npcSurvivor.squareZ
+        );
     end
-    return false;
+    -- Cows: if the npcSquare is still nil, the square is unloaded.
+    if (npcSquare == nil) then
+        return false;
+    end
+    return true;
 end
 
 ---comment
@@ -484,23 +492,25 @@ function PZNS_UtilsNPCs.PZNS_ClearNPCAllNeedsLevel(npcSurvivor)
     end
     --
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
-    npcIsoPlayer:getStats():setAnger(0.0);
-    npcIsoPlayer:getStats():setBoredom(0.0);
-    npcIsoPlayer:getStats():setDrunkenness(0.0);
-    npcIsoPlayer:getStats():setEndurance(100.0);
-    npcIsoPlayer:getStats():setFatigue(0.0);
-    npcIsoPlayer:getStats():setFear(0.0);
-    npcIsoPlayer:getStats():setHunger(0.0);
-    npcIsoPlayer:getStats():setIdleboredom(0.0);
-    npcIsoPlayer:getStats():setMorale(0.0);
-    npcIsoPlayer:getStats():setPain(0.0);
-    npcIsoPlayer:getStats():setPanic(0.0);
-    npcIsoPlayer:getStats():setSanity(0.0);
-    npcIsoPlayer:getStats():setSickness(0.0);
-    npcIsoPlayer:getStats():setStress(0.0);
-    npcIsoPlayer:getStats():setStressFromCigarettes(0.0);
-    npcIsoPlayer:getStats():setThirst(0.0);
-    npcIsoPlayer:getBodyDamage():AddGeneralHealth(25);
+    if (npcIsoPlayer) then
+        npcIsoPlayer:getStats():setAnger(0.0);
+        npcIsoPlayer:getStats():setBoredom(0.0);
+        npcIsoPlayer:getStats():setDrunkenness(0.0);
+        npcIsoPlayer:getStats():setEndurance(100.0);
+        npcIsoPlayer:getStats():setFatigue(0.0);
+        npcIsoPlayer:getStats():setFear(0.0);
+        npcIsoPlayer:getStats():setHunger(0.0);
+        npcIsoPlayer:getStats():setIdleboredom(0.0);
+        npcIsoPlayer:getStats():setMorale(0.0);
+        npcIsoPlayer:getStats():setPain(0.0);
+        npcIsoPlayer:getStats():setPanic(0.0);
+        npcIsoPlayer:getStats():setSanity(0.0);
+        npcIsoPlayer:getStats():setSickness(0.0);
+        npcIsoPlayer:getStats():setStress(0.0);
+        npcIsoPlayer:getStats():setStressFromCigarettes(0.0);
+        npcIsoPlayer:getStats():setThirst(0.0);
+        npcIsoPlayer:getBodyDamage():AddGeneralHealth(25);
+    end
 end
 
 --- Cows: Clears ALL npcs' needs on call.

--- a/PZNS_Framework/media/lua/client/04_data_management/PZNS_NPCsManager.lua
+++ b/PZNS_Framework/media/lua/client/04_data_management/PZNS_NPCsManager.lua
@@ -96,8 +96,8 @@ function PZNS_NPCsManager.deleteActiveNPCBySurvivorID(survivorID)
         -- Cows Check if IsoPlayer object exists.
         if (npcIsoPlayer ~= nil) then
             -- Cows: Remove the IsoPlayer from the world then nil the table key-value data.
-            npcIsoPlayer:removeFromWorld();
             npcIsoPlayer:removeFromSquare();
+            npcIsoPlayer:removeFromWorld();
             npcIsoPlayer:removeSaveFile(); -- Cows: Remove the IsoPlayer SaveFile? I am curious about how it tracks the save file...
         end
         activeNPCs[survivorID] = nil;

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_ManageJobs.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_ManageJobs.lua
@@ -10,7 +10,7 @@ local PZNS_NPCGroupsManager = require("04_data_management/PZNS_NPCGroupsManager"
 
 -- Cows: Init PZNS_CellZombiesList as an empty table, which can then be used by all NPCs to evaluate the zombie threat.
 PZNS_CellZombiesList = nil; -- WIP - Cows: Need to rethink how Global variables are used...
-PZNS_CellNPCsList = {};    -- WIP - Cows: Need to rethink how Global variables are used...
+PZNS_CellNPCsList = {};     -- WIP - Cows: Need to rethink how Global variables are used...
 
 -- WIP - Cows: Need to rethink how Global variables are used...
 PZNS_JobsText = {
@@ -93,3 +93,17 @@ function PZNS_UpdateAllJobsRoutines()
         PZNS_UpdateNPCJobRoutine(npcSurvivor);
     end
 end
+
+local PZNS_ManageJobs = {};
+
+--- Cows: Input a JobName (without space) and associated JobFunction to make the NPC run on a custom job AI.
+---@param JobName string
+---@param JobFunction any
+function PZNS_ManageJobs.updatePZNSJobsTable(JobName, JobFunction)
+    -- Cows: Check if the JobName is not in the table.
+    if (PZNS_Jobs[JobName] == nil) then
+        PZNS_Jobs[JobName] = JobFunction;
+    end
+end
+
+return PZNS_ManageJobs;

--- a/PZNS_Framework/media/lua/client/11_events_spawning/PZNS_HotKeys.lua
+++ b/PZNS_Framework/media/lua/client/11_events_spawning/PZNS_HotKeys.lua
@@ -1,5 +1,6 @@
 --- Cows: Key press activated functions.
 local PZNS_DebuggerUtils = require("02_mod_utils/PZNS_DebuggerUtils");
+local PZNS_WorldUtils = require("02_mod_utils/PZNS_WorldUtils");
 
 local function doNothing()
 end
@@ -8,7 +9,7 @@ function PZNS_KeyBindAction(keyNum)
     --- Cows: Intended for Debug and Testing only
     local keyPressed = "k" .. tostring(keyNum);
     local keyMap = {
-        k55 = doNothing,                                       -- numpad *
+        k55 = PZNS_WorldUtils.PZNS_SpawnNPCIfSquareIsLoaded,   -- numpad *
         k71 = PZNS_DebuggerUtils.PZNS_GetAllObjectsInCell,     -- numpad 7
         k72 = PZNS_DebuggerUtils.PZNS_LogPlayerCellGridSquare, -- numpad 8
         k73 = PZNS_DebuggerUtils.PZNS_LogPlayerCustomization,  -- numpad 9
@@ -17,7 +18,7 @@ function PZNS_KeyBindAction(keyNum)
         k76 = PZNS_DebuggerUtils.LogNPCsModData,               -- numpad 5
         k77 = PZNS_DebuggerUtils.LogZonesModData,              -- numpad 6
         k78 = doNothing,                                       -- numpad +
-        k79 = doNothing,                                -- numpad 1
+        k79 = doNothing,                                       -- numpad 1
         k80 = doNothing,                                       -- numpad 2
         k81 = doNothing,                                       -- numpad 3
         -- k82 = doNothing,                    -- numpad 0 -- Cows: Do not use this key for now, it is used in "Proximity Inventory" https://steamcommunity.com/sharedfiles/filedetails/?id=2847184718


### PR DESCRIPTION
PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsDataNPCs.lua
- PZNS_SpawnNPCFromModData() - Added flag initailization - npcSurvivor.isSavedInWorld = false;

PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
- PZNS_GetIsNPCSquareLoaded() - Added IsoPlayer object check, in case it exists because it has already been loaded.

PZNS_Framework/media/lua/client/02_mod_utils/PZNS_WorldUtils.lua
- spawnNPCIsoPlayer() - Updated and added more checks.
  - Somehow missed the fact the "npcSurvivor" object isn't always up-to-date... as it is only updated when saving. 
  -  IsoPlayer object (if the NPC is already spawned) is actually the most accurate in-game location of the NPC.
  - This should fix and prevent issues of companion NPCs turning into ghosts when moving too fast and too far away from them.
  - 'npcSurvivor' object now resets the IsoPlayer object to nil when out of spawn range.

PZNS_Framework/media/lua/client/04_data_management/PZNS_NPCsManager.lua
- Updated order of execution when removing IsoPlayer object from square and world.

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_ManageJobs.lua
- Added a function that allows modders to update the "PZNS_Jobs" table
  - Which in theory should allow a mod's custom AI to be added to the PZNS framework. (To-be-verified)

PZNS_Framework/media/lua/client/11_events_spawning/PZNS_HotKeys.lua
- Added the spawnRange check on keypress test, can be removed in the future.