### PR TITLE
Ticks update

### DIFF
--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsDataNPCs.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsDataNPCs.lua
@@ -135,7 +135,11 @@ function PZNS_UtilsDataNPCs.PZNS_SpawnNPCFromModData(npcSurvivor)
             npcSurvivorDesc,
             npcSurvivor.squareX, npcSurvivor.squareY, npcSurvivor.squareZ
         );
-        --
+        -- Cows: Reset the ticks counter.
+        npcSurvivor.actionTicks = 0;
+        npcSurvivor.idleTicks = 0;
+        npcSurvivor.isStuckTicks = 0;
+        npcSurvivor.jobTicks = 0;
         npcSurvivor.npcIsoPlayerObject = npcIsoPlayerObject;
         npcSurvivor.npcIsoPlayerObject:load(npcFileName);
         npcSurvivor.npcIsoPlayerObject:setNPC(true);

--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsDataNPCs.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsDataNPCs.lua
@@ -173,21 +173,4 @@ function PZNS_UtilsDataNPCs.PZNS_ClearNPCModData()
     ModData.remove("PZNS_ActiveNPCs");
 end
 
---- WIP - UNUSED CURRENTLY - Cows: Check if the NPC save file exists in the game save directory.
-function PZNS_UtilsDataNPCs.PZNS_CheckIfSaveFileExists(npcSurvivorID)
-    local npcFileName = PZNS_UtilsDataNPCs.PZNS_GetGameSaveDir() .. tostring(npcSurvivorID);
-    return false;
-end
-
---- WIP - UNUSED CURRENTLY - Cows: Called to clean up PZNS_ActiveNPCs moddata if save file doesn't exist for the NPC.
---- Cows: May be useless, because clean up is already done in PZNS_InitLoadNPCsData()
-function PZNS_UtilsDataNPCs.PZNS_RemoveAllNPCsWithoutSaveFile()
-    for npcSurvivorID, npcSurvivor in pairs(PZNS_ActiveNPCs) do
-        local isFileExists = PZNS_UtilsDataNPCs.PZNS_CheckIfSaveFileExists(npcSurvivorID);
-        if (isFileExists == false) then
-            PZNS_ActiveNPCs[npcSurvivorID] = nil;
-        end
-    end
-end
-
 return PZNS_UtilsDataNPCs;

--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
@@ -529,9 +529,6 @@ end
 ---@param npcSurvivor any
 ---@param tickInterval number
 function PZNS_UtilsNPCs.PZNS_StuckNPCCheck(npcSurvivor, tickInterval)
-    if (npcSurvivor.isStuckTicks == nil) then
-        npcSurvivor.isStuckTicks = 0;
-    end
     -- Cows: 50 Ticks per action on average... also need ticks for animations.
     if (npcSurvivor.isStuckTicks > tickInterval) then
         PZNS_NPCSpeak(npcSurvivor, "I was stuck...", "InfoOnly");

--- a/PZNS_Framework/media/lua/client/03_mod_core/PZNS_NPCSurvivor.lua
+++ b/PZNS_Framework/media/lua/client/03_mod_core/PZNS_NPCSurvivor.lua
@@ -30,12 +30,14 @@ function PZNS_NPCSurvivor:newSurvivor(
         jobSquare = nil,                        -- Cows: The square at which the NPC do its job (pickup item, chop tree, etc.)
         isJobRefreshed = false,                 -- Cows: This is a flag to check for NPCs to "refresh" their job status.
         currentAction = "",                     -- Cows: This is a value to check for NPCs to queue or not queue up more actions.
-        isStuckTicks = 0,                       -- Cows: This is a value to check if NPC is "stuck" or doing nothing even though it has a job.
         followTargetID = "",                    -- Cows: Used to follow a specified object managed by PZNS IDs
         speechTable = nil,                      -- Cows: Used when adding speech table(s), if nil, NPCs should use PresetsSpeeches instead.
         lastEquippedMeleeWeapon = "",           -- WIP - Cows: Added so that NPCs can resume using this melee weapon after completing an action.
         lastEquippedRangeWeapon = "",           -- WIP - Cows: Added so that NPCs can resume using this range weapon after completing an action.
         idleTicks = 0,                          -- Cows: Used to track how long an NPC is idle for before they take some general AI stuff.
+        isStuckTicks = 0,                       -- Cows: Used check if NPC is "stuck" or doing nothing even though it has a job.
+        moveTicks = 0,                          -- Cows: Used to track how long the NPC is moving about. Added to determine how often to update pathing.
+        jobTicks = 0,                           -- Cows: Used to track how often NPCs updates their job routine. This was added because actionTicks is intended for actions only.
         actionTicks = 0,                        -- Cows: This is a value used to determine the frequency of an action being called, most notably with multi-stage actions (such as reloading).
         attackTicks = 0,                        -- Cows: I thought it was stupid at first, but after observing an NPC queue up 20+ attacks in a a single frame...
         speechTicks = 0,                        -- Cows: Tracks the ticks between speech text... ticks are inconsistent, but there are currently no other short duration timers.

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_EnterVehicle.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_EnterVehicle.lua
@@ -33,10 +33,12 @@ function PZNS_ExitVehicle(npcSurvivor)
     end
     --
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
-    local currentVehicle = npcIsoPlayer:getVehicle();
-    local currentSeat = npcIsoPlayer:getVehicle():getSeat(npcIsoPlayer);
+    -- local currentVehicle = npcIsoPlayer:getVehicle();
+    -- local currentSeat = npcIsoPlayer:getVehicle():getSeat(npcIsoPlayer);
     local exitCarAction = ISExitVehicle:new(npcIsoPlayer);
-    local closeCarDoorAction = ISCloseVehicleDoor:new(npcIsoPlayer, currentVehicle, currentSeat);
+    -- local closeCarDoorAction = ISCloseVehicleDoor:new(npcIsoPlayer, currentVehicle, currentSeat);
     PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, exitCarAction);
-    PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, closeCarDoorAction);
+    -- PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, closeCarDoorAction); -- WIP - Cows: NPCs don't seem to close the door on exit no matter what I try...
+    -- WIP - Cows: Curious, I have observed the player actions seems to lock the player keyboard controls randomly when NPCs exit the vehicle...
+    -- WIP - Cows: The current workaround is to open the context menu, and select "Walk to" a square, which then unlocks the player key inputs.
 end

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponReload.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponReload.lua
@@ -5,6 +5,7 @@ function PZNS_WeaponReload(npcSurvivor)
     if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
+    ---@type IsoPlayer
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
     local npcHandItem = npcIsoPlayer:getPrimaryHandItem();
     if (npcHandItem == nil) then
@@ -29,6 +30,7 @@ function PZNS_WeaponReload(npcSurvivor)
         local npc_inventory = npcIsoPlayer:getInventory();
         local bestMagazine = npcHandItem:getBestMagazine(npcIsoPlayer);
         local magazine = npc_inventory:getFirstTypeRecurse(npcHandItem:getMagazineType());
+        local weaponAmmoType = npcHandItem:getAmmoType();
         --
         if (bestMagazine) then
             if (lastAction) then
@@ -36,6 +38,9 @@ function PZNS_WeaponReload(npcSurvivor)
                 if (lastAction.Type ~= "ISLoadBulletsInMagazine" and actionsCount > 1) then
                     PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
                 end
+            end
+            if (IsInfiniteAmmoActive == true and npcHandItem:getCurrentAmmoCount() == 0) then
+                PZNS_UtilsNPCs.PZNS_AddItemsToInventoryNPCSurvivor(npcSurvivor, weaponAmmoType, npcHandItem:getMaxAmmo());
             end
             -- PZNS_NPCSpeak(npcSurvivor, "Reloading... Inserting Mag into Gun");
             PZNS_GunMagazineInsert(npcSurvivor);
@@ -51,6 +56,9 @@ function PZNS_WeaponReload(npcSurvivor)
         end
         -- End Magazine based reload
     else
+        if (IsInfiniteAmmoActive == true and npcHandItem:getCurrentAmmoCount() == 0) then
+            PZNS_UtilsNPCs.PZNS_AddItemsToInventoryNPCSurvivor(npcSurvivor, weaponAmmoType, npcHandItem:getMaxAmmo());
+        end
         -- Cows: Testing this out, but ISReloadWeaponAction seems to have worked for SS/SSC...
         ISTimedActionQueue.add(ISReloadWeaponAction:new(npcIsoPlayer, npcHandItem));
     end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
@@ -133,6 +133,7 @@ function PZNS_GeneralAI.PZNS_NPCAimAttack(npcSurvivor)
     end
     -- Cows: Can only aim and/or attack aimTarget exists
     if (npcSurvivor.aimTarget ~= nil) then
+        -- WIP - Cows: Should add a check to see if enemy is in range... 
         PZNS_WeaponAiming(npcSurvivor); -- Cows: Aim before attacking
         PZNS_WeaponAttack(npcSurvivor); -- Cows: Permission to attack is handled in the function.
     end
@@ -327,7 +328,7 @@ function PZNS_GeneralAI.PZNS_WalkToJobSquare(npcSurvivor)
     end
     -- Cows: Else Update the movement calculation every 200 ticks to reduce action queuing and resume the movement.
     local moveTickInterval = 200;
-    if (npcSurvivor.idleTicks >= moveTickInterval) then
+    if (npcSurvivor.moveTicks >= moveTickInterval) then
         -- Cows: Check the NPC at regular intervals to see if it is stuck in the same square...
         local isStuck = npcIsoPlayer:getLastSquare() == npcPlayerSquare;
         if (isStuck == true) then
@@ -348,8 +349,9 @@ function PZNS_GeneralAI.PZNS_WalkToJobSquare(npcSurvivor)
             PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor); -- Cows: Clear the actions queue and start moving.
             PZNS_WalkToSquareXYZ(npcSurvivor, squareX, squareY, squareZ);
         end
-        npcSurvivor.idleTicks = 0;
+        npcSurvivor.moveTicks = 0;
     end
+    npcSurvivor.moveTicks = npcSurvivor.moveTicks + 1;
 end
 
 -- Cows: Helper function for exploring a specified target building.

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
@@ -35,8 +35,8 @@ function PZNS_JobGuard(npcSurvivor)
         --
         if (npcSurvivor.jobSquare ~= nil) then
             -- Cows: let the guard NPC resume its walking patrol along the zone perimeter.
-            npcSurvivor.actionTicks = npcSurvivor.actionTicks + 1;
-            if (npcSurvivor.actionTicks >= 30) then
+            npcSurvivor.jobTicks = npcSurvivor.jobTicks + 1;
+            if (npcSurvivor.jobTicks >= 30) then
                 local squareX = npcSurvivor.jobSquare:getX();
                 local squareY = npcSurvivor.jobSquare:getY();
                 local squareZ = npcSurvivor.jobSquare:getZ();
@@ -49,7 +49,7 @@ function PZNS_JobGuard(npcSurvivor)
                 -- );
                 PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor); -- Cows: Clear the actions queue and start moving.
                 PZNS_WalkToSquareXYZ(npcSurvivor, squareX, squareY, squareZ);
-                npcSurvivor.actionTicks = 0;
+                npcSurvivor.jobTicks = 0;
             end
             local distanceFromTarget = PZNS_WorldUtils.PZNS_GetDistanceBetweenTwoObjects(
                 playerSquare,
@@ -106,11 +106,7 @@ function PZNS_JobGuard(npcSurvivor)
             end
         end
     else
-        npcSurvivor.actionTicks = npcSurvivor.actionTicks + 1;
-        if (npcSurvivor.actionTicks >= 30) then
-            PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
-            PZNS_GeneralAI.PZNS_WalkToJobSquare(npcSurvivor);
-            npcSurvivor.actionTicks = 0;
-        end
+        PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
+        PZNS_GeneralAI.PZNS_WalkToJobSquare(npcSurvivor);
     end
 end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobUndertaker.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobUndertaker.lua
@@ -99,8 +99,8 @@ function PZNS_JobUndertaker(npcSurvivor)
     --
     debugDropSquare = groupDropSquare;
     -- Cows: Check the job every 30 ticks or so, which should ease the burden of doing everything every tick.
-    npcSurvivor.actionTicks = npcSurvivor.actionTicks + 1;
-    if (npcSurvivor.actionTicks >= 30) then
+    npcSurvivor.jobTicks = npcSurvivor.jobTicks + 1;
+    if (npcSurvivor.jobTicks >= 30) then
         -- Cows: Check if the NPC has a male corpse in the inventory.
         local inventoryCorpse = npcIsoPlayer:getInventory():FindAndReturn("CorpseMale");
         -- Cows: Then check if there is no corpse in the inventory and look for a female corpse.
@@ -172,6 +172,6 @@ function PZNS_JobUndertaker(npcSurvivor)
                 end
             end -- Cows: End cellCorpseSquares loop.
         end
-        npcSurvivor.actionTicks = 0;
+        npcSurvivor.jobTicks = 0;
     end
 end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInBuilding.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInBuilding.lua
@@ -29,14 +29,13 @@ function PZNS_JobWanderInBuilding(npcSurvivor)
                 PZNS_GeneralAI.PZNS_ExploreTargetBuilding(npcSurvivor, targetBuilding);
             end
         else
-            -- Cows: use idleTicks instead of action ticks, because the NPC is wandering around without a group goal. Also because other actions may use actionTicks.
-            npcSurvivor.idleTicks = npcSurvivor.idleTicks + 1;
+            npcSurvivor.jobTicks = npcSurvivor.jobTicks + 1;
             -- Cows: Else assume the NPC is moving inside the building it is in.
             local distanceFromTarget = PZNS_WorldUtils.PZNS_GetDistanceBetweenTwoObjects(
                 npcIsoPlayer, npcSurvivor.jobSquare
             );
             --- Cows: Check if the NPC path is blocked every 60 ticks or so.
-            if (npcSurvivor.idleTicks % 60 == 0) then
+            if (npcSurvivor.jobTicks % 60 == 0) then
                 if (PZNS_GeneralAI.PZNS_IsPathBlocked(npcSurvivor) == true) then
                     PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
                     npcSurvivor.jobSquare = nil;
@@ -46,7 +45,7 @@ function PZNS_JobWanderInBuilding(npcSurvivor)
             -- Cows: Check if the NPC is near its destination...
             if (distanceFromTarget < 1) then
                 -- Cows: Allow the NPC to idle for a moment before restarting its routine.
-                if (npcSurvivor.idleTicks >= 600) then
+                if (npcSurvivor.jobTicks >= 600) then
                     PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
                     npcSurvivor.jobSquare = nil;
                 end
@@ -56,8 +55,7 @@ function PZNS_JobWanderInBuilding(npcSurvivor)
             end
         end
     else
-        -- Cows: Else assume the npcSurvivor is holding in place, but will attempt to walk to any assigned jobSquare.
-        npcSurvivor.idleTicks = npcSurvivor.idleTicks + 1;
+        PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
         PZNS_GeneralAI.PZNS_WalkToJobSquare(npcSurvivor);
     end
 end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInCell.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInCell.lua
@@ -50,14 +50,13 @@ function PZNS_JobWanderInCell(npcSurvivor)
             return;
         end
     else
-        -- Cows: use idleTicks instead of action ticks, because the NPC is wandering around without a group goal. Also because other actions may use actionTicks.
-        npcSurvivor.idleTicks = npcSurvivor.idleTicks + 1;
+        npcSurvivor.jobTicks = npcSurvivor.jobTicks + 1;
         -- Cows: Else assume the NPC is moving inside the building it is in.
         local distanceFromTarget = PZNS_WorldUtils.PZNS_GetDistanceBetweenTwoObjects(
             npcIsoPlayer, npcSurvivor.jobSquare
         );
         --- Cows: Check if the NPC path is blocked every 60 ticks or so.
-        if (npcSurvivor.idleTicks % 60 == 0) then
+        if (npcSurvivor.jobTicks % 60 == 0) then
             if (PZNS_GeneralAI.PZNS_IsPathBlocked(npcSurvivor) == true) then
                 PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
                 npcSurvivor.jobSquare = nil;


### PR DESCRIPTION
PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsDataNPCs.lua
- Resets tick counters to 0 on load to prevent potential mishaps.
- Removed unused test functions
  - PZNS_CheckIfSaveFileExists()
  - PZNS_RemoveAllNPCsWithoutSaveFile

PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
- Removed unneeded condition check for isStuckTicks

PZNS_Framework/media/lua/client/03_mod_core/PZNS_NPCSurvivor.lua
- Added "moveTicks" for tracking and potentially updating pathing
- Added "jobTicks" for tracking and updating job routines
- Added and updated comments for ticks counters

PZNS_Framework/media/lua/client/05_npc_actions/PZNS_EnterVehicle.lua
- Added some new comments regarding player keyboard inputs when NPCs exit vehicles.

PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponReload.lua
- NPC weapons should now auto-refill when out of ammo and IsInfiniteAmmoActive is true.

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
- Updated, replacing idleTicks with moveTicks 

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobGuard.lua
- Updated, replacing actionTicks with jobTicks

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobUndertaker.lua
- Updated, replacing actionTicks with jobTicks

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInBuilding.lua
- Updated, replacing idleTicks with jobTicks

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobWanderInCell.lua
- Updated, replacing idleTicks with jobTicks

PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobsCompanion.lua
- Updated, replacing actionTicks with jobTicks
  - Movement related actions now update at set ticks intervals, rather than every tick (should improve overall game performance).
- 