### PR TITLE
Updated vehicle exit function to handle possible RV interiors issue.

### DIFF
--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_EnterVehicle.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_EnterVehicle.lua
@@ -1,4 +1,5 @@
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
+local PZNS_DebuggerUtils = require("02_mod_utils/PZNS_DebuggerUtils");
 
 ---comment
 ---@param npcSurvivor any
@@ -25,20 +26,27 @@ function PZNS_EnterVehicleAsPassenger(npcSurvivor, targetIsoPlayer)
     end
 end
 
----comment
+-- WIP - Cows: Curious, I have observed the exit action seems to lock the player keyboard controls randomly whenever NPCs exit the vehicle...
+-- WIP - Cows: The current workaround is to open the context menu, and select "Walk to" a square, which then unlocks the player key inputs.
 ---@param npcSurvivor any
 function PZNS_ExitVehicle(npcSurvivor)
     if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
     end
-    --
+    ---@type IsoPlayer
     local npcIsoPlayer = npcSurvivor.npcIsoPlayerObject;
-    -- local currentVehicle = npcIsoPlayer:getVehicle();
-    -- local currentSeat = npcIsoPlayer:getVehicle():getSeat(npcIsoPlayer);
-    local exitCarAction = ISExitVehicle:new(npcIsoPlayer);
-    -- local closeCarDoorAction = ISCloseVehicleDoor:new(npcIsoPlayer, currentVehicle, currentSeat);
-    PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, exitCarAction);
-    -- PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, closeCarDoorAction); -- WIP - Cows: NPCs don't seem to close the door on exit no matter what I try...
-    -- WIP - Cows: Curious, I have observed the player actions seems to lock the player keyboard controls randomly when NPCs exit the vehicle...
-    -- WIP - Cows: The current workaround is to open the context menu, and select "Walk to" a square, which then unlocks the player key inputs.
+    -- Cows: Check if the RV Interiors is loaded and if the NPC's square is loaded on screen.
+    if (PZNS_DebuggerUtils.PZNS_IsModActive("RV_Interior_MP") == true and npcIsoPlayer:getSquare():IsOnScreen() ~= true) then
+        -- Cows: RV Interiors works by teleporting the player to a new map (literally)... so the NPC and the vehicle it is in will *most* likely not be on screen.
+        PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor); -- Cows: Clear the actions queue, the NPC can't do anything while the player is inside RV interior.
+        return;
+    else
+        -- Cows: Else use vanilla assets, exit the vehicle.
+        -- local currentVehicle = npcIsoPlayer:getVehicle();
+        -- local currentSeat = npcIsoPlayer:getVehicle():getSeat(npcIsoPlayer);
+        local exitCarAction = ISExitVehicle:new(npcIsoPlayer);
+        -- local closeCarDoorAction = ISCloseVehicleDoor:new(npcIsoPlayer, currentVehicle, currentSeat);
+        PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, exitCarAction);
+        -- PZNS_UtilsNPCs.PZNS_AddNPCActionToQueue(npcSurvivor, closeCarDoorAction); -- WIP - Cows: NPCs don't seem to close the door on exit no matter what I try...
+    end
 end


### PR DESCRIPTION
- Confirmed and updated for limited RV Interiors support
  - RV Interiors works by teleporting the player to the new RV interior map... and I will not be writing a teleporter function for NPCs to follow players into the RV Interiors.
  - However, I have confirmed that NPCs will remain where they were on the world map whenever the player enters/exits the RV interiors.
  - Because the NPCs are intended to work with the vanilla world map, I cannot guarantee consistent data being saved when the map is loaded, unloaded in a completely different and separate mod.
- So, this leaves me with "limited" rather than full compatibility with RV Interiors.
- Video - https://www.youtube.com/watch?v=YW3aEUswLPo