### PR TITLE
NPC core classes and manager update

### DIFF
--- a/PZNS_Framework/media/lua/client/00_references/init.lua
+++ b/PZNS_Framework/media/lua/client/00_references/init.lua
@@ -1,0 +1,25 @@
+PZNS = PZNS or {}
+PZNS.Core = PZNS.Core or {}
+PZNS.Context = PZNS.Context or {}
+PZNS.Context.Debug = PZNS.Context.Debug or {}
+PZNS.UI = PZNS.UI or {}
+
+PZNS.Core.NPC = {}
+PZNS.Core.Group = {}
+PZNS.Core.Faction = {}
+PZNS.Core.Zone = {}
+
+---@type table<survivorID, NPC>
+PZNS.Core.NPC.registry = {}
+---@type table<groupID, Group>
+PZNS.Core.Group.registry = {}
+---@type table<factionID, NPCFaction>
+PZNS.Core.Faction.registry = {}
+---@type table<zoneID, Zone>
+PZNS.Core.Zone.registry = {}
+
+
+---@alias survivorID string Unique identifier for survivor
+---@alias groupID string Unique identifier for group
+---@alias factionID string Unique identifier for faction
+---@alias zoneID string Unique identifier for zone

--- a/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
+++ b/PZNS_Framework/media/lua/client/02_mod_utils/PZNS_UtilsNPCs.lua
@@ -172,9 +172,9 @@ function PZNS_UtilsNPCs.PZNS_EquipLastWeaponNPCSurvivor(npcSurvivor)
     local weaponItem = nil
     --
     if (npcSurvivor.isMeleeOnly == true) then -- TODO reuse item from inventory if any of the same type
-        weaponItem = instanceItem(npcSurvivor.lastEquippedMeleeWeapon);
+        weaponItem = instanceItem(npcSurvivor.lastEquippedMeleeWeapon or "");
     else
-        weaponItem = instanceItem(npcSurvivor.lastEquippedRangeWeapon);
+        weaponItem = instanceItem(npcSurvivor.lastEquippedRangeWeapon or "");
     end
     --
     if (weaponItem ~= nil) then

--- a/PZNS_Framework/media/lua/client/03_mod_core/PZNS_NPCSurvivor.lua
+++ b/PZNS_Framework/media/lua/client/03_mod_core/PZNS_NPCSurvivor.lua
@@ -1,61 +1,109 @@
-PZNS_NPCSurvivor = {};
-PZNS_NPCSurvivor.__index = PZNS_NPCSurvivor;
+require("00_references/init")
+
+---@class NPC
+---@field survivorID survivorID               Unique identifier for this NPC
+---@field groupID groupID?                    Unique identifier of the group this NPC belongs to, if any
+---@field survivorName string                 NPC name
+---@field affection integer                   WIP - Cows: Added this value as a check for invite-able NPCs... between 0 and 100? 0 Means 100% hostility and will attack. (deprecated)
+---@field isForcedMoving boolean              Cows: Added this flag to force NPCs to move and disengage from combat/other actions.
+---@field isHoldingInPlace boolean            Cows: Prevent current NPC from moving if true
+---@field isMeleeOnly boolean                 WIP - Cows: Will eventually be used in more complex combat AI.
+---@field isRaider boolean                    WIP - Cows: Used to test raiding NPCs
+---@field isSavedInWorld boolean              Cows: Added so that NPC can be checked and saved when it is off-screen.
+---@field courage integer                     WIP - Cows: Considered for evaluating when NPCs should "flee" from hostility
+---@field jobName string                      Current job of this NPC; Cows: Defaults to a job managed by PZNS
+---@field jobSquare IsoGridSquare?            Cows: The square at which the NPC do its job (pickup item, chop tree, etc.)
+---@field isJobRefreshed boolean              Cows: This is a flag to check for NPCs to "refresh" their job status.
+---@field currentAction string                Cows: This is a value to check for NPCs to queue or not queue up more actions.
+---@field isStuckTicks integer                Cows: Used check if NPC is "stuck" or doing nothing even though it has a job.
+---@field moveTicks integer                   Cows: Used to track how long the NPC is moving about. Added to determine how often to update pathing.
+---@field jobTicks integer                    Cows: Used to track how often NPCs updates their job routine. This was added because actionTicks is intended for actions only.
+---@field followTargetID survivorID           Cows: Used to follow a specified object managed by PZNS IDs
+---@field speechTable table?                  Cows: Used when adding speech table(s), if nil, NPCs should use PresetsSpeeches instead.
+---@field lastEquippedMeleeWeapon HandWeapon? WIP - Cows: Added so that NPCs can resume using this melee weapon after completing an action.
+---@field lastEquippedRangeWeapon HandWeapon? WIP - Cows: Added so that NPCs can resume using this range weapon after completing an action.
+---@field idleTicks integer                   Cows: Used to track how long an NPC is idle for before they take some general AI stuff.
+---@field actionTicks integer                 Cows: This is a value used to determine the frequency of an action being called, most notably with multi-stage actions (such as reloading).
+---@field attackTicks integer                 Cows: I thought it was stupid at first, but after observing an NPC queue up 20+ attacks in a a single frame...
+---@field speechTicks integer                 Cows: Tracks the ticks between speech text... ticks are inconsistent, but there are currently no other short duration timers.
+---@field aimTarget IsoGameCharacter?         Cows: Used to identify the object the NPC is to aim at... but Java API has a "NPCSetAiming()" call which is confusing...
+---@field canAttack boolean                   Cows: Added to prevent NPCs from taking attacking actions; Java API has a "NPCSetAttack()" call which is confusing; as it appears to force the NPC to attack.
+---@field canSaveData boolean                 WIP - Cows: Added this flag to determine if NPC can be saved via data management.
+---@field textObject TextDrawObject?          Cows: This should handle all the text displayed by the NPC. Not used if `isPlayer=true`
+---IsoPlayer Spawning Related fields
+---@field isAlive boolean               WIP - Technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
+---@field isSpawned boolean             WIP - Technically part of IsoPlayer... but "isExistInTheWorld()" seems very inconsistent...
+---@field forename string               Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
+---@field surname string                Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
+---@field isFemale boolean              Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
+---@field squareX integer?              Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
+---@field squareY integer?              Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
+---@field squareZ integer?              Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
+---@field npcIsoPlayerObject IsoPlayer  Cows: objects cannot be saved to moddata...
+local NPC = {}
 
 --- Cows: Construct the PZNS_NPCSurvivor.
----@param survivorID any                -- Cows: Unique Identifier for the current NPC
+---@param survivorID survivorID         -- Cows: Unique Identifier for the current NPC
 ---@param survivorName any              -- Cows: Current NPC's name
 ---@param npcIsoPlayerObject IsoPlayer  -- Cows: The actual IsoPlayer object the current NPC is spawned in as. NPCUtils will mostly interact with this object.
 ---@return table
-function PZNS_NPCSurvivor:newSurvivor(
+function NPC:new(
     survivorID,
     survivorName,
     npcIsoPlayerObject
 )
-    local npcSurvivor = {};
-    setmetatable(npcSurvivor, self);
-    self.__index = self;
-
-    npcSurvivor = {
+    local npcSurvivor = {
         survivorID = survivorID,
         survivorName = survivorName,
         groupID = nil,
-        affection = 50,                         -- WIP - Cows: Added this value as a check for invite-able NPCs... between 0 and 100? 0 Means 100% hostility and will attack.
-        isForcedMoving = false,                 -- Cows: Added this flag to force NPCs to move and disengage from combat/other actions.
-        isHoldingInPlace = false,               -- Cows: Prevent current NPC from moving if true
-        isMeleeOnly = false,                    -- WIP - Cows: Will eventually be used in more complex combat AI.
-        isRaider = false,                       -- WIP - Cows: Used to test raiding NPCs
-        isSavedInWorld = false,                 -- Cows: Added so that NPC can be checked and saved when it is off-screen.
-        courage = 50,                           -- WIP - Cows: Considered for evaluating when NPCs should "flee" from hostility
-        jobName = "Guard",                      -- Cows: Defaults to a job managed by PZNS
-        jobSquare = nil,                        -- Cows: The square at which the NPC do its job (pickup item, chop tree, etc.)
-        isJobRefreshed = false,                 -- Cows: This is a flag to check for NPCs to "refresh" their job status.
-        currentAction = "",                     -- Cows: This is a value to check for NPCs to queue or not queue up more actions.
-        followTargetID = "",                    -- Cows: Used to follow a specified object managed by PZNS IDs
-        speechTable = nil,                      -- Cows: Used when adding speech table(s), if nil, NPCs should use PresetsSpeeches instead.
-        lastEquippedMeleeWeapon = "",           -- WIP - Cows: Added so that NPCs can resume using this melee weapon after completing an action.
-        lastEquippedRangeWeapon = "",           -- WIP - Cows: Added so that NPCs can resume using this range weapon after completing an action.
-        idleTicks = 0,                          -- Cows: Used to track how long an NPC is idle for before they take some general AI stuff.
-        isStuckTicks = 0,                       -- Cows: Used check if NPC is "stuck" or doing nothing even though it has a job.
-        moveTicks = 0,                          -- Cows: Used to track how long the NPC is moving about. Added to determine how often to update pathing.
-        jobTicks = 0,                           -- Cows: Used to track how often NPCs updates their job routine. This was added because actionTicks is intended for actions only.
-        actionTicks = 0,                        -- Cows: This is a value used to determine the frequency of an action being called, most notably with multi-stage actions (such as reloading).
-        attackTicks = 0,                        -- Cows: I thought it was stupid at first, but after observing an NPC queue up 20+ attacks in a a single frame...
-        speechTicks = 0,                        -- Cows: Tracks the ticks between speech text... ticks are inconsistent, but there are currently no other short duration timers.
-        aimTarget = "",                         -- Cows: Used to identify the object the NPC is to aim at... but Java API has a "NPCSetAiming()" call which is confusing...
-        canAttack = true,                       -- Cows: Added to prevent NPCs from taking attacking actions; Java API has a "NPCSetAttack()" call which is confusing; as it appears to force the NPC to attack.
-        canSaveData = true,                     -- WIP - Cows: Added this flag to determine if NPC can be saved via data management.
-        textObject = nil,                       -- Cows: This should handle all the text displayed by the NPC.
+        affection = 50,
+        isForcedMoving = false,
+        isHoldingInPlace = false,
+        isMeleeOnly = false,
+        isRaider = false,
+        isSavedInWorld = false,
+        courage = 50,
+        jobName = "Guard",
+        jobSquare = nil,
+        isJobRefreshed = false,
+        currentAction = "",
+        followTargetID = "",
+        speechTable = nil,
+        lastEquippedMeleeWeapon = nil,
+        lastEquippedRangeWeapon = nil,
+        idleTicks = 0,
+        isStuckTicks = 0,
+        moveTicks = 0,
+        jobTicks = 0,
+        actionTicks = 0,
+        attackTicks = 0,
+        speechTicks = 0,
+        aimTarget = "",
+        canAttack = true,
+        canSaveData = true,
+        textObject = nil,
         ------ IsoPlayer Spawning Related below ------
-        isAlive = true,                         -- WIP - Technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
-        isSpawned = true,                       -- WIP - Technically part of IsoPlayer... but "isExistInTheWorld()" seems very inconsistent...
-        forename = "",                          -- Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
-        surname = "",                           -- Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
-        isFemale = false,                       -- Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
-        squareX = nil,                          -- Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
-        squareY = nil,                          -- Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
-        squareZ = nil,                          -- Cows: Placeholder; technically part of IsoPlayer; used when PZNS needs to use it before IsoPlayer is loaded.
-        npcIsoPlayerObject = npcIsoPlayerObject -- Cows: objects cannot be saved to moddata...
+        isAlive = true,
+        isSpawned = true,
+        forename = "",
+        surname = "",
+        isFemale = false,
+        squareX = nil,
+        squareY = nil,
+        squareZ = nil,
+        npcIsoPlayerObject = npcIsoPlayerObject
     };
+
+    setmetatable(npcSurvivor, self);
+    self.__index = self;
 
     return npcSurvivor;
 end
+
+---Assigns groupID to NPC
+---@param groupID groupID?
+function NPC:setGroupID(groupID)
+    self.groupID = groupID
+end
+
+return NPC

--- a/PZNS_Framework/media/lua/client/04_data_management/PZNS_NPCsManager.lua
+++ b/PZNS_Framework/media/lua/client/04_data_management/PZNS_NPCsManager.lua
@@ -1,60 +1,116 @@
+require("00_references/init")
+
 local PZNS_UtilsDataNPCs = require("02_mod_utils/PZNS_UtilsDataNPCs");
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
+local PZNS_UtilsDataGroups = require("02_mod_utils/PZNS_UtilsDataGroups")
+local NPC = require("03_mod_core/PZNS_NPCSurvivor")
+local fmt = string.format
 
 PZNS_ActiveInventoryNPC = {}; -- WIP - Cows: Need to rethink how Global variables are used...
 
 local PZNS_NPCsManager = {};
 
---- Cows: The PZNS_NPCSurvivor uses the IsoPlayer from the base game as one of its properties.
---- Best to think of the other properties of PZNS_NPCSurvivor as extended properties for PZNS.
----@param survivorID any -- Cows: Need a way to guarantee this is unique...
+---Get NPC by its survivorID
+---@param survivorID survivorID
+---@return NPC?
+function PZNS_NPCsManager.getNPC(survivorID)
+    local activeNPCs = PZNS_UtilsDataNPCs.PZNS_GetCreateActiveNPCsModData();
+    return activeNPCs[survivorID]
+end
+
+---Try to find NPC by its isoObject
+---@param isoPlayer IsoPlayer
+---@return NPC?
+function PZNS_NPCsManager.findNPCByIsoObject(isoPlayer)
+    local activeNPCs = PZNS_UtilsDataNPCs.PZNS_GetCreateActiveNPCsModData();
+    for _, npc in pairs(activeNPCs) do
+        if npc.npcIsoPlayerObject == isoPlayer then
+            return npc
+        end
+    end
+end
+
+---Get Group by its groupID
+---@param groupID groupID
+---@return Group?
+local function getGroup(groupID)
+    local activeGroups = PZNS_UtilsDataGroups.PZNS_GetCreateActiveGroupsModData()
+    return activeGroups[groupID]
+end
+
+---Create IsoPlayer object with provided params at `square`
+---@param square IsoGridSquare Square that NPC will spawn on
 ---@param isFemale boolean
 ---@param surname string
 ---@param forename string
----@param square IsoGridSquare
----@return unknown
+---@param survivorID survivorID unique ID, will be set to isoPlayer modData
+---@return IsoPlayer isoPlayer player object
+---@return integer squareZ Z-level that NPC was created at
+local function createIsoPlayer(square, isFemale, surname, forename, survivorID)
+    local squareZ = 0;
+    -- Cows: It turns out this check is needed, otherwise NPCs may spawn in the air and fall...
+    if (square:isSolidFloor()) then
+        squareZ = square:getZ();
+    end
+    --
+    local survivorDescObject = PZNS_UtilsDataNPCs.PZNS_CreateNPCSurvivorDescObject(isFemale, surname, forename);
+    local npcIsoPlayerObject = IsoPlayer.new(
+        getWorld():getCell(),
+        survivorDescObject,
+        square:getX(),
+        square:getY(),
+        squareZ
+    );
+    --
+    npcIsoPlayerObject:getModData().survivorID = survivorID;
+    --
+    npcIsoPlayerObject:setForname(forename); -- Cows: In case forename wasn't set...
+    npcIsoPlayerObject:setSurname(surname);  -- Cows: Apparently the surname set at survivorDesc isn't automatically set to IsoPlayer...
+    npcIsoPlayerObject:setNPC(true);
+    npcIsoPlayerObject:setSceneCulled(false);
+    return npcIsoPlayerObject, squareZ
+end
+
+--- Cows: The PZNS_NPCSurvivor uses the IsoPlayer from the base game as one of its properties.
+--- Best to think of the other properties of PZNS_NPCSurvivor as extended properties for PZNS.
+---@param survivorID survivorID -- Cows: Need a way to guarantee this is unique...
+---@param isFemale boolean
+---@param surname string
+---@param forename string
+---@param square IsoGridSquare Square that NPC will spawn on
+---@param isoPlayer IsoPlayer? if passed - skip IsoPlayer creation
+---@return NPC
 function PZNS_NPCsManager.createNPCSurvivor(
     survivorID,
     isFemale,
     surname,
     forename,
-    square
+    square,
+    isoPlayer
 )
     -- Cows: Check if the survivorID is present before proceeding.
     if (survivorID == nil) then
-        return nil;
+        error("survivorID not set")
     end
-    local activeNPCs = PZNS_UtilsDataNPCs.PZNS_GetCreateActiveNPCsModData();
     local npcSurvivor = nil;
     -- Cows: Now add the npcSurvivor to the PZNS_NPCsManager if the ID does not exist.
-    if (activeNPCs[survivorID] == nil) then
-        local squareZ = 0;
-        -- Cows: It turns out this check is needed, otherwise NPCs may spawn in the air and fall...
-        if (square:isSolidFloor()) then
-            squareZ = square:getZ();
-        end
-        --
-        local survivorDescObject = PZNS_UtilsDataNPCs.PZNS_CreateNPCSurvivorDescObject(isFemale, surname, forename);
-        local npcIsoPlayerObject = IsoPlayer.new(
-            getWorld():getCell(),
-            survivorDescObject,
-            square:getX(),
-            square:getY(),
-            squareZ
-        );
-        --
-        npcIsoPlayerObject:getModData().survivorID = survivorID;
-        --
-        npcIsoPlayerObject:setForname(forename); -- Cows: In case forename wasn't set...
-        npcIsoPlayerObject:setSurname(surname);  -- Cows: Apparently the surname set at survivorDesc isn't automatically set to IsoPlayer...
-        npcIsoPlayerObject:setNPC(true);
-        npcIsoPlayerObject:setSceneCulled(false);
+    local npc = PZNS_NPCsManager.getNPC(survivorID)
+    local squareZ = 0
+    if (not npc) then
         local survivorName = forename .. " " .. surname; -- Cows: in case getName() functions break down or can't be used...
         --
-        npcSurvivor = PZNS_NPCSurvivor:newSurvivor(
+        if not isoPlayer then
+            isoPlayer, squareZ = createIsoPlayer(square, isFemale, surname, forename, survivorID)
+        else
+            assert(instanceof(isoPlayer, "IsoPlayer"), "isoPlayer is not valid!")
+            squareZ = isoPlayer:getSquare():getZ()
+        end
+
+        ---@type NPC
+        npcSurvivor = NPC:new(
             survivorID,
             survivorName,
-            npcIsoPlayerObject
+            isoPlayer
         );
         npcSurvivor.isFemale = isFemale;
         npcSurvivor.forename = forename;
@@ -69,14 +125,38 @@ function PZNS_NPCsManager.createNPCSurvivor(
         npcSurvivor.textObject:ReadString(survivorName);
     else
         -- WIP - Cows: Alert player the ID is already used and the NPC cannot be created.
+        npcSurvivor = npc
+        if not isoPlayer then
+            isoPlayer, squareZ = createIsoPlayer(square, isFemale, surname, forename, survivorID)
+        end
+        assert(isoPlayer, "IsoPlayer missing, can't create NPC")
+        npcSurvivor.npcIsoPlayerObject = isoPlayer
     end
-
     return npcSurvivor;
 end
 
+---Set NPC group ID to groupID
+---@param survivorID survivorID
+---@param groupID groupID? leave empty to unset group
+function PZNS_NPCsManager.setGroupID(survivorID, groupID)
+    local npc = PZNS_NPCsManager.getNPC(survivorID)
+    if not npc then
+        print(fmt("NPC not found! ID: %s", survivorID))
+        return
+    end
+    if groupID then
+        local group = getGroup(groupID)
+        if not group then
+            print(fmt("Group not found! ID: %s", groupID))
+            return
+        end
+    end
+    NPC.setGroupID(npc, groupID)
+end
+
 ---Cows: Get a npcSurvivor by specified survivorID
----@param survivorID any
----@return any
+---@param survivorID survivorID
+---@return NPC?
 function PZNS_NPCsManager.getActiveNPCBySurvivorID(survivorID)
     local activeNPCs = PZNS_UtilsDataNPCs.PZNS_GetCreateActiveNPCsModData();
     if (activeNPCs[survivorID] ~= nil) then
@@ -86,7 +166,7 @@ function PZNS_NPCsManager.getActiveNPCBySurvivorID(survivorID)
 end
 
 ---Cows: Delete a npcSurvivor by specified survivorID
----@param survivorID any
+---@param survivorID survivorID
 function PZNS_NPCsManager.deleteActiveNPCBySurvivorID(survivorID)
     local activeNPCs = PZNS_UtilsDataNPCs.PZNS_GetCreateActiveNPCsModData();
     local npcSurvivor = activeNPCs[survivorID];
@@ -105,7 +185,7 @@ function PZNS_NPCsManager.deleteActiveNPCBySurvivorID(survivorID)
 end
 
 ---comment
----@param survivorID any
+---@param survivorID survivorID
 function PZNS_NPCsManager.setActiveInventoryNPCBySurvivorID(survivorID)
     local activeNPCs = PZNS_UtilsDataNPCs.PZNS_GetCreateActiveNPCsModData();
     local npcSurvivor = activeNPCs[survivorID];
@@ -114,9 +194,9 @@ end
 
 --- WIP - Cows: Spawn a random raider NPC.
 --- Cows: Go make your own random spawns, this is an example for debugging and testing.
----@param targetSquare IsoGridSquare
----@param raiderID string | nil
----@return unknown
+---@param targetSquare IsoGridSquare square to spawn NPC on
+---@param raiderID string | nil if provided - will be used as survivorID for NPC
+---@return NPC raider created raider NPC
 function PZNS_NPCsManager.spawnRandomRaiderSurvivorAtSquare(targetSquare, raiderID)
     local isFemale = ZombRand(100) > 50; -- Cows: 50/50 roll for female spawn
     local raiderForeName = SurvivorFactory.getRandomForename(isFemale);
@@ -168,9 +248,9 @@ end
 
 --- WIP - Cows: Spawn a random NPC.
 --- Cows: Go make your own random spawns, this is an example for debugging and testing.
----@param targetSquare IsoGridSquare
----@param survivorID string | nil
----@return unknown
+---@param targetSquare IsoGridSquare square to spawn NPC on
+---@param survivorID string | nil if provided - will be used as survivorID for NPC
+---@return NPC survivor created survivor NPC
 function PZNS_NPCsManager.spawnRandomNPCSurvivorAtSquare(targetSquare, survivorID)
     local isFemale = ZombRand(100) > 50; -- Cows: 50/50 roll for female spawn
     local npcForeName = SurvivorFactory.getRandomForename(isFemale);

--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponReload.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponReload.lua
@@ -1,6 +1,6 @@
 local PZNS_UtilsNPCs = require("02_mod_utils/PZNS_UtilsNPCs");
 ---comment
----@param npcSurvivor any
+---@param npcSurvivor NPC
 function PZNS_WeaponReload(npcSurvivor)
     if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then
         return;
@@ -11,6 +11,7 @@ function PZNS_WeaponReload(npcSurvivor)
     if (npcHandItem == nil) then
         return;
     end
+    ---@cast npcHandItem HandWeapon
     --
     npcIsoPlayer:NPCSetAttack(false);
     if (npcIsoPlayer:NPCGetAiming() == true) then
@@ -21,6 +22,7 @@ function PZNS_WeaponReload(npcSurvivor)
     local lastAction = actionQueue.queue[#actionQueue.queue];
     -- Cows: Magazine based reload
     local magazineType = npcHandItem:getMagazineType();
+    local weaponAmmoType = npcHandItem:getAmmoType();
     if (magazineType ~= nil) then
         -- Cows: If there are more than 3 actions queued, reset the queue so the NPC can start reloading right away.
         if (actionsCount > 3) then
@@ -30,7 +32,6 @@ function PZNS_WeaponReload(npcSurvivor)
         local npc_inventory = npcIsoPlayer:getInventory();
         local bestMagazine = npcHandItem:getBestMagazine(npcIsoPlayer);
         local magazine = npc_inventory:getFirstTypeRecurse(npcHandItem:getMagazineType());
-        local weaponAmmoType = npcHandItem:getAmmoType();
         --
         if (bestMagazine) then
             if (lastAction) then


### PR DESCRIPTION
- `00_references/init.lua` - global variable (`PZNS`) and all necessary namespaces.
    `.registry` tables will eventually be used as a reference to relevant part of ModData for easier access across the codebase
- `03_mod_core/PZNS_NPCSurvivor` - Added typings, descriptions and core methods for NPC management
    - Changed default values for `lastEquippedXWeapon` to nil (as those will store reference to `InventoryItem`). Added default value (empty string) when calling `instanceItem` in `PZNS_UtilsNPCs.PZNS_AddEquipWeaponNPCSurvivor` to avoid error.
- `04_data_management/PZNS_NPCsManager` - changed logic in `createNPCSurvivor`, moved creation of IsoPlayer to separate function and added ability to provide existing `IsoPlayer` (to create PZNS NPC only)
- `05_npc_actions/PZNS_WeaponReload` - Fixed bug in `PZNS_WeaponReload` caused by unknown variable `weaponAmmoType` (was declared out of scope)