### PR TITLE
Ammo spam fix

### DIFF
--- a/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponReload.lua
+++ b/PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponReload.lua
@@ -22,7 +22,6 @@ function PZNS_WeaponReload(npcSurvivor)
     local lastAction = actionQueue.queue[#actionQueue.queue];
     -- Cows: Magazine based reload
     local magazineType = npcHandItem:getMagazineType();
-    local weaponAmmoType = npcHandItem:getAmmoType();
     if (magazineType ~= nil) then
         -- Cows: If there are more than 3 actions queued, reset the queue so the NPC can start reloading right away.
         if (actionsCount > 3) then
@@ -40,9 +39,6 @@ function PZNS_WeaponReload(npcSurvivor)
                     PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
                 end
             end
-            if (IsInfiniteAmmoActive == true and npcHandItem:getCurrentAmmoCount() == 0) then
-                PZNS_UtilsNPCs.PZNS_AddItemsToInventoryNPCSurvivor(npcSurvivor, weaponAmmoType, npcHandItem:getMaxAmmo());
-            end
             -- PZNS_NPCSpeak(npcSurvivor, "Reloading... Inserting Mag into Gun");
             PZNS_GunMagazineInsert(npcSurvivor);
         else
@@ -57,9 +53,6 @@ function PZNS_WeaponReload(npcSurvivor)
         end
         -- End Magazine based reload
     else
-        if (IsInfiniteAmmoActive == true and npcHandItem:getCurrentAmmoCount() == 0) then
-            PZNS_UtilsNPCs.PZNS_AddItemsToInventoryNPCSurvivor(npcSurvivor, weaponAmmoType, npcHandItem:getMaxAmmo());
-        end
         -- Cows: Testing this out, but ISReloadWeaponAction seems to have worked for SS/SSC...
         ISTimedActionQueue.add(ISReloadWeaponAction:new(npcIsoPlayer, npcHandItem));
     end

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
@@ -62,6 +62,12 @@ function PZNS_GeneralAI.PZNS_IsReloadNeeded(npcSurvivor)
     end
     -- Cows: Ranged weapon
     if (npcHandItem:IsWeapon() == true and npcHandItem:isRanged() == true) then
+        -- Cows: Refill the gun to full capacity if infinite ammo is active.
+        if (IsInfiniteAmmoActive == true and npcHandItem:getCurrentAmmoCount() == 0) then
+            PZNS_UtilsNPCs.PZNS_ClearQueuedNPCActions(npcSurvivor);
+            PZNS_UtilsNPCs.PZNS_SetLoadedGun(npcSurvivor);
+            return false;
+        end
         local ammoType = npcHandItem:getAmmoType();
         ammoCount = npc_inventory:getItemCountRecurse(ammoType);
         -- Cows: Check if the gun has no ammo and there are ammo in the backpack or there is a magazine type but no magazine is in the gun.

--- a/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobsCompanion.lua
+++ b/PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobsCompanion.lua
@@ -108,7 +108,7 @@ local function jobCompanion_Movement(npcSurvivor, targetIsoPlayer)
 end
 
 --- Cows: The "Companion" Job only works if the npcSurvivor and its target exists.
----@param npcSurvivor NPC
+---@param npcSurvivor PZNS_NPCSurvivor
 ---@param targetID string
 function PZNS_JobCompanion(npcSurvivor, targetID)
     if (PZNS_UtilsNPCs.IsNPCSurvivorIsoPlayerValid(npcSurvivor) == false) then


### PR DESCRIPTION
PZNS_Framework/media/lua/client/07_npc_ai/PZNS_JobsCompanion.lua
- Found a type linter issue, updated to fix linter issue.

PZNS_Framework/media/lua/client/05_npc_actions/PZNS_WeaponReload.lua
- Removed adding ammo to inventory when infinite ammo is active.
  - This was unintentionally spam-adding the ammo into NPC inventory.
  
PZNS_Framework/media/lua/client/07_npc_ai/PZNS_GeneralAI.lua
- A hotfix to refill/reload guns to capacity while infinite ammo is active.